### PR TITLE
Do not fail during initalization when Highcharts is not instantiated

### DIFF
--- a/packages/react-jsx-highcharts/src/components/Tooltip/Tooltip.js
+++ b/packages/react-jsx-highcharts/src/components/Tooltip/Tooltip.js
@@ -13,7 +13,7 @@ class Tooltip extends Component {
   };
 
   static defaultProps = {
-    ...Highcharts.defaultOptions.tooltip,
+    ...(Highcharts.defaultOptions && Highcharts.defaultOptions.tooltip),
     enabled: true
   };
 

--- a/packages/react-jsx-highstock/src/components/RangeSelector/RangeSelector.js
+++ b/packages/react-jsx-highstock/src/components/RangeSelector/RangeSelector.js
@@ -13,7 +13,7 @@ class RangeSelector extends Component {
   };
 
   static defaultProps = {
-    ...Highcharts.defaultOptions.rangeSelector,
+    ...(Highcharts.defaultOptions && Highcharts.defaultOptions.rangeSelector),
     enabled: true
   };
 


### PR DESCRIPTION
Our application uses universal rendering. It turns out, if there is no `window` in the current environment (such as server rendering), the `'highcharts'` dependency returns a factory function, not the Highcharts namespace instance. Because of this, a failure happens at [Tooltip.js#L16](https://github.com/whawker/react-jsx-highcharts/blob/master/packages/react-jsx-highcharts/src/components/Tooltip/Tooltip.js#L16).

This pull request attempts to solve the problem by checking whether the `Highcharts.defaultOptions` do exist when initializing `Tooltip`'s `defaultProps`, so the application doesn't fail on class definition. Usage of `Highcharts` inside methods (`Highcharts.addEvent()`, `Highcharts.chart()` etc.) needs further research though.