### PR TITLE
Build ES6 module for highcharts

### DIFF
--- a/packages/react-jsx-highcharts/.babelrc
+++ b/packages/react-jsx-highcharts/.babelrc
@@ -12,6 +12,9 @@
     },
     "production": {
       "plugins": ["lodash", "transform-runtime", "transform-react-remove-prop-types"]
+    },
+    "es": {
+      "plugins": ["./build/use-lodash-es", "lodash", "transform-runtime", "transform-react-remove-prop-types"]
     }
   }
 }

--- a/packages/react-jsx-highcharts/build/use-lodash-es.js
+++ b/packages/react-jsx-highcharts/build/use-lodash-es.js
@@ -1,0 +1,10 @@
+module.exports = function() {
+  return {
+    visitor: {
+      ImportDeclaration(path) {
+        var source = path.node.source
+        source.value = source.value.replace(/^lodash($|\/)/, 'lodash-es$1')
+      },
+    },
+  }
+}

--- a/packages/react-jsx-highcharts/package.json
+++ b/packages/react-jsx-highcharts/package.json
@@ -84,7 +84,8 @@
   "dependencies": {
     "immutable-is": "^3.7.6",
     "is-immutable": "^1.0.1",
-    "lodash": "^4.17.4"
+    "lodash": "^4.17.4",
+    "lodash-es": "^4.17.4"
   },
   "peerDependencies": {
     "highcharts": "^5.0.0 || ^6.0.0",

--- a/packages/react-jsx-highcharts/package.json
+++ b/packages/react-jsx-highcharts/package.json
@@ -12,7 +12,7 @@
   "scripts": {
     "build": "cross-env NODE_ENV=development ./node_modules/.bin/webpack",
     "build:prod": "cp ../../README.md . && cross-env NODE_ENV=production ./node_modules/.bin/webpack -p",
-    "build:es": "BABEL_ENV=production babel src --out-dir dist/es",
+    "build:es": "BABEL_ENV=es babel src --out-dir dist/es",
     "lint": "./node_modules/.bin/eslint src",
     "test": "cross-env NODE_ENV=test ./node_modules/.bin/mocha --compilers js:babel-core/register --require test/test-helper.js test/**/*.spec.js"
   },

--- a/packages/react-jsx-highcharts/package.json
+++ b/packages/react-jsx-highcharts/package.json
@@ -3,6 +3,8 @@
   "version": "2.2.1",
   "description": "Highcharts charts built using React components",
   "main": "dist/react-jsx-highcharts.min.js",
+  "module": "dist/es/index.js",
+  "sideEffects": false,
   "files": [
     "dist",
     "src"
@@ -10,6 +12,7 @@
   "scripts": {
     "build": "cross-env NODE_ENV=development ./node_modules/.bin/webpack",
     "build:prod": "cp ../../README.md . && cross-env NODE_ENV=production ./node_modules/.bin/webpack -p",
+    "build:es": "BABEL_ENV=production babel src --out-dir dist/es",
     "lint": "./node_modules/.bin/eslint src",
     "test": "cross-env NODE_ENV=test ./node_modules/.bin/mocha --compilers js:babel-core/register --require test/test-helper.js test/**/*.spec.js"
   },

--- a/packages/react-jsx-highcharts/package.json
+++ b/packages/react-jsx-highcharts/package.json
@@ -69,7 +69,7 @@
     "html-webpack-plugin": "^2.28.0",
     "immutable": "^3.8.1",
     "jsdom": "^11.0.0",
-    "lodash-webpack-plugin": "^0.11.4",
+    "lodash-webpack-plugin": "^0.11.5",
     "mocha": "^3.4.1",
     "prop-types": "^15.0.0",
     "react": "^16.0.0",


### PR DESCRIPTION
This PR adds ES module build for react-jsx-highcharts.
This lets webpack 4 do tree shaking and module concatenation which saves me around 50kB in final bundle.

As I am not too familiar with the source code, I am not 100% sure that setting "sideEffects": false is entirely safe. On the surface it seems to be.
The sideEffects flag can also be array of globs if there are side effects of importing some modules.

It also modifies the ES build to use lodash-es instead of lodash. That babel plugin is copied from https://github.com/PaulLeCam/react-leaflet
The lodash-es allows some more tree shaking.
As there is no commonjs build, the lodash-es could be used in unmodified source too.

I also tried building UMD with webpack 4 and that also saves some space. I can make separate PR for it if you like?

I did not add this build to highstock package as I don't have real world application to test it with.

Do you think this is okay to be included in react-jsx-highcharts?