### PR TITLE
Fix uuid uniqueness

### DIFF
--- a/packages/react-jsx-highcharts/src/components/Axis/Axis.js
+++ b/packages/react-jsx-highcharts/src/components/Axis/Axis.js
@@ -11,7 +11,7 @@ class Axis extends Component {
 
   static propTypes = {
     type: validAxisTypes,
-    id: PropTypes.string.isRequired,
+    id: PropTypes.string,
     children: PropTypes.node,
     getChart: PropTypes.func, // Provided by ChartProvider
     getHighcharts: PropTypes.func.isRequired, // Provided by HighchartsProvider
@@ -19,13 +19,13 @@ class Axis extends Component {
   };
 
   static defaultProps = {
-    id: uuid(),
     children: null,
     dynamicAxis: true
   };
 
-  componentWillMount () {
-    const { dynamicAxis, isX, getChart, ...rest } = this.props;
+  componentDidMount () {
+    const { dynamicAxis, isX, getChart, id, ...rest } = this.props;
+    rest.id = id || uuid();
     const nonEventProps = getNonEventHandlerProps(rest);
     const chart = getChart();
 
@@ -36,11 +36,9 @@ class Axis extends Component {
       this.axis = chart.get('zAxis');
       this.axis.update(Object.assign({ title: { text: null } }, nonEventProps), true);
     }
-  }
-
-  componentDidMount () {
     const update = this.axis.update.bind(this.axis)
     addEventProps(update, this.props);
+    this.forceUpdate();
   }
 
   componentDidUpdate (prevProps) {
@@ -55,11 +53,16 @@ class Axis extends Component {
   }
 
   render () {
-    return (
-      <Provider value={this.axis}>
-        {this.props.children}
-      </Provider>
-    );
+    if (this.axis) {
+      return (
+        <Provider value={this.axis}>
+          {this.props.children}
+        </Provider>
+      );
+    } else {
+      return null;
+    }
+
   }
 }
 

--- a/packages/react-jsx-highcharts/src/components/Series/Series.js
+++ b/packages/react-jsx-highcharts/src/components/Series/Series.js
@@ -12,7 +12,7 @@ import getModifiedProps from '../../utils/getModifiedProps';
 class Series extends Component {
 
   static propTypes = {
-    id: PropTypes.string.isRequired,
+    id: PropTypes.string,
     type: PropTypes.string.isRequired,
     axisId: PropTypes.string, // Provided by Axis component
     dimension: PropTypes.string, // Provided by Axis component
@@ -28,7 +28,6 @@ class Series extends Component {
   };
 
   static defaultProps = {
-    id: uuid(),
     type: 'line',
     children: null,
     data: [],
@@ -36,8 +35,9 @@ class Series extends Component {
     visible: true
   };
 
-  componentWillMount () {
-    const { data, requiresAxis, getChart, getAxis, children, ...rest } = this.props;
+  componentDidMount () {
+    const { data, requiresAxis, getChart, getAxis, children, id, ...rest } = this.props;
+    rest.id = id || uuid();
     const seriesData = isImmutable(data) ? data.toJS() : data;
     const nonEventProps = getNonEventHandlerProps(rest);
     const chart = getChart();
@@ -53,11 +53,11 @@ class Series extends Component {
     }
 
     this.series = chart.addSeries(opts, true);
-  }
 
-  componentDidMount () {
     const update = this.series.update.bind(this.series)
     addEventProps(update, this.props);
+
+    this.forceUpdate();
   }
 
   componentDidUpdate (prevProps) {
@@ -84,11 +84,16 @@ class Series extends Component {
   }
 
   render () {
-    return (
-      <Provider value={this.series}>
-        {this.props.children}
-      </Provider>
-    )
+    if (this.series) {
+      return (
+        <Provider value={this.series}>
+          {this.props.children}
+        </Provider>
+      )
+    } else {
+      return null;
+    }
+
   }
 }
 


### PR DESCRIPTION
Makes Axis and Series uuid's unique for every instance.

Also drops deprecated componentWillMount from those classes. Options3d I did not know how to test, although removing it from there looks straight forward.

This might not be the cleanest approach, and it might have bugs..
Feel free to ignore if you come up with some better way.