### PR TITLE
Remove default xaxis id

### DIFF
--- a/packages/react-jsx-highcharts/src/components/XAxis/XAxis.js
+++ b/packages/react-jsx-highcharts/src/components/XAxis/XAxis.js
@@ -10,9 +10,6 @@ class XAxis extends Component {
     getChart: PropTypes.func.isRequired // Provided by ChartProvider
   };
 
-  static defaultProps = {
-    id: 'xAxis'
-  };
 
   render () {
     let { getChart, ...rest } = this.props;


### PR DESCRIPTION
Removes the xAxis id default value. This makes it possible to add multiple XAxises without providing id's.

Hope it doesn't have any special meaning somewhere else.