### PR TITLE
Update datepickers build to webpack 4

### DIFF
--- a/packages/react-jsx-highstock-datepickers/.babelrc
+++ b/packages/react-jsx-highstock-datepickers/.babelrc
@@ -1,13 +1,12 @@
 {
-  "plugins": ["transform-runtime"],
+  "plugins": ["transform-runtime", "transform-class-properties", "transform-object-rest-spread"],
   "presets": [
-    ["es2015", { "modules": false }],
-    "react",
-    "stage-0"
+    ["env", { "modules": false }],
+    "react"
   ],
   "env": {
     "test": {
-      "presets": ["es2015", "react", "stage-0"]
+      "plugins": ["transform-es2015-modules-commonjs"]
     },
     "production": {
       "plugins": ["transform-runtime", "transform-react-remove-prop-types"]

--- a/packages/react-jsx-highstock-datepickers/package.json
+++ b/packages/react-jsx-highstock-datepickers/package.json
@@ -9,7 +9,7 @@
   ],
   "scripts": {
     "build": "cross-env NODE_ENV=development ./node_modules/.bin/webpack",
-    "build:prod": "cross-env NODE_ENV=production ./node_modules/.bin/webpack -p"
+    "build:prod": "cross-env NODE_ENV=production ./node_modules/.bin/webpack"
   },
   "repository": {
     "type": "git",
@@ -33,19 +33,20 @@
     "react-jsx-highstock": "^2.0.0"
   },
   "devDependencies": {
-    "babel-cli": "^6.24.1",
-    "babel-core": "^6.25.0",
-    "babel-loader": "^7.1.1",
+    "babel-cli": "^6.26.0",
+    "babel-core": "^6.26.0",
+    "babel-loader": "^7.1.4",
+    "babel-plugin-transform-class-properties": "^6.24.1",
+    "babel-plugin-transform-object-rest-spread": "^6.26.0",
     "babel-plugin-transform-react-remove-prop-types": "^0.4.8",
     "babel-plugin-transform-runtime": "^6.23.0",
-    "babel-preset-es2015": "^6.24.1",
+    "babel-preset-env": "^1.6.1",
     "babel-preset-react": "^6.24.1",
-    "babel-preset-stage-0": "^6.24.1",
     "cross-env": "^5.0.5",
-    "css-loader": "^0.28.4",
-    "extract-text-webpack-plugin": "^2.0.0",
+    "css-loader": "^0.28.11",
+    "mini-css-extract-plugin": "^0.4.0",
     "null-loader": "^0.1.1",
-    "style-loader": "^0.18.2",
-    "webpack": "^2.7.0"
+    "webpack": "^4.8.3",
+    "webpack-cli": "^2.1.3"
   }
 }

--- a/packages/react-jsx-highstock-datepickers/webpack.config.js
+++ b/packages/react-jsx-highstock-datepickers/webpack.config.js
@@ -1,12 +1,13 @@
 const webpack = require('webpack');
 const path = require('path');
 const fs = require('fs');
-const ExtractTextPlugin = require('extract-text-webpack-plugin');
+const MiniCssExtractPlugin = require("mini-css-extract-plugin");
 
 const isProd = (process.env.NODE_ENV === 'production');
 const babelSettings = JSON.parse(fs.readFileSync('.babelrc'));
 
 const webpackConfig = {
+  mode: 'development',
   entry: path.resolve(__dirname, 'src'),
 
   output: {
@@ -66,45 +67,34 @@ const webpackConfig = {
         loader: 'babel-loader',
         exclude: /node_modules/,
         query: babelSettings
+      },
+      {
+        test: /\.css$/,
+        use: [
+          {
+            loader: MiniCssExtractPlugin.loader
+          },
+          {
+            loader: "css-loader",
+            options: {
+              sourceMap: true,
+              minimize: true
+            }
+          }
+        ]
       }
     ]
   },
-
   plugins: [
-    new webpack.DefinePlugin({
-      'process.env': {
-        'NODE_ENV': JSON.stringify(process.env.NODE_ENV)
-      }
+    new MiniCssExtractPlugin({
+      filename  : 'index.css'
     })
   ]
 };
 
-const extractStyles = new ExtractTextPlugin({
-  filename  : 'index.css'
-});
-webpackConfig.module.rules.push(
-  {
-    test: /\.css$/,
-    loader: extractStyles.extract({
-      fallback: 'style-loader',
-      use: [
-        {
-          loader: 'css-loader',
-          options: {
-            sourceMap: true,
-            minimize: true
-          }
-        }
-      ]
-    })
-  }
-);
-webpackConfig.plugins.push(extractStyles);
 
 if (isProd) {
-  webpackConfig.plugins.push(
-    new webpack.optimize.UglifyJsPlugin()
-  );
+  webpackConfig.mode = 'production';
 }
 
 module.exports = webpackConfig;


### PR DESCRIPTION
This updates datepickers to use webpack 4. Doesn't save much space, but it is more consistent with other modules.

I didn't test this at all, because I have never used it. Hope it still helps a little to release 3.0.0.

