### PR TITLE
Add flow typings for external API

### DIFF
--- a/packages/react-jsx-highcharts/.flowconfig
+++ b/packages/react-jsx-highcharts/.flowconfig
@@ -1,0 +1,14 @@
+[ignore]
+.*/dist/.*
+
+[include]
+
+[libs]
+
+[lints]
+
+[options]
+suppress_comment=\\(.\\|\n\\)*\\$ExpectError
+include_warnings=true
+
+[strict]

--- a/packages/react-jsx-highcharts/package.json
+++ b/packages/react-jsx-highcharts/package.json
@@ -11,10 +11,14 @@
   ],
   "scripts": {
     "build": "cross-env NODE_ENV=development ./node_modules/.bin/webpack",
-    "build:prod": "cp ../../README.md . && cross-env NODE_ENV=production ./node_modules/.bin/webpack",
+    "build:prod": "npm run build:umd && npm run build:es && npm run build:copyfiles",
+    "build:umd": "cross-env NODE_ENV=production ./node_modules/.bin/webpack",
     "build:es": "BABEL_ENV=es babel src --out-dir dist/es",
+    "build:copyfiles": "cp ../../README.md . && cp src/index.js.flow dist/react-jsx-highcharts.min.js.flow",
     "lint": "./node_modules/.bin/eslint src",
-    "test": "cross-env NODE_ENV=test ./node_modules/.bin/mocha ./test -name '*.spec.js' --recursive --require babel-core/register --require test/test-helper.js"
+    "test": "npm run test:mocha && npm run test:flow",
+    "test:mocha": "cross-env NODE_ENV=test ./node_modules/.bin/mocha ./test -name '*.spec.js' --recursive --require babel-core/register --require test/test-helper.js",
+    "test:flow": "flow check"
   },
   "author": "Will Hawker",
   "contributors": [
@@ -77,6 +81,7 @@
     "eslint-plugin-import": "^2.2.0",
     "eslint-plugin-jsx-a11y": "^5.1.1",
     "eslint-plugin-react": "^7.8.2",
+    "flow-bin": "^0.73.0",
     "highcharts": "^6.0.0",
     "html-webpack-include-assets-plugin": "1.0.4",
     "html-webpack-plugin": "^3.2.0",

--- a/packages/react-jsx-highcharts/src/index.js.flow
+++ b/packages/react-jsx-highcharts/src/index.js.flow
@@ -1,0 +1,182 @@
+// @flow
+import React from 'react';
+import type { Node, ComponentType, ElementConfig } from 'react';
+import type HighchartsType from 'highcharts';
+
+
+type HighchartsChartProps = {
+  children?: Node
+}
+
+export function HighchartsChart(props: HighchartsChartProps) { }
+
+type HighchartsSparklineProps = {
+  height?: number,
+  width?: number,
+  margin?: Array<number>,
+  style?: {},
+  plotOptions?: {},
+  series?: Node,// note series or children required
+} & HighchartsChartProps
+
+export class HighchartsSparkline extends React.Component<HighchartsSparklineProps> { }
+
+
+type Highcharts3dChartProps = {
+  alpha?: number,
+  axisLabelPosition?: string,
+  beta?: number,
+  depth?: number,
+  fitToPlot?: boolean,
+  frame?: {},
+  viewDistance?: number,
+} & HighchartsChartProps;
+
+export class Highcharts3dChart extends React.Component<Highcharts3dChartProps> {
+
+}
+
+type ChartProps = {
+  type?: string,
+  width?: number,
+  height?: number,
+  onAddSeries?: Function,
+  onAfterPrint?: Function,
+  onBeforePrint?: Function,
+  onClick?: Function,
+  onLoad?: Function,
+  onRedraw?: Function,
+  onRender?: Function,
+  onSelection?: Function,
+}
+export function Chart (props: ChartProps) {}
+type CreditsProps = {
+  enabled?: boolean
+}
+export function Credits (props:CreditsProps) { }
+type LoadingProps = {
+  isLoading?: boolean,
+  hideDuration?: number,
+  labelStyle?: {},
+  showDuration?: number,
+  style?: {},
+}
+export function Loading (props: LoadingProps) { }
+
+type LegendProps = {
+  children?: Node,
+  enabled?: boolean
+}
+type LegendTitleProps = {
+  children?: Node
+}
+function LegendTitle (props: LegendTitleProps) { }
+export function Legend (props: LegendProps) {
+
+}
+Legend.Title = LegendTitle;
+
+type PlotBandProps = {
+  id?: string,
+  from: any,
+  to: any,
+  color?: string,
+}
+type PlotBandLabelProps = {
+  children: Node
+}
+function PlotBandLabel (props: PlotBandLabelProps) { }
+export function PlotBand(props: PlotBandProps) {
+
+}
+PlotBand.Label = PlotBandLabel;
+
+type PlotLineProps = {
+  id?: string,
+  value: any,
+  color?: string,
+}
+type PlotLineLabelProps = {
+  children: Node
+}
+function PlotLineLabel (props: PlotLineLabelProps) { }
+export function PlotLine (props:PlotLineProps) {
+
+}
+PlotLine.Label = PlotLineLabel;
+
+type SubtitleProps = {
+  children: Node
+}
+export function Subtitle (props: SubtitleProps) { }
+
+type TitleProps = {
+  children: Node
+}
+export function Title (props: TitleProps) { }
+
+type TooltipProps = {
+  children: Node,
+  enabled?: boolean
+}
+export function Tooltip (props:TooltipProps) { }
+
+type AxisProps = {
+  type?: 'category' | 'linear' | 'logarithmic' | 'datetime',
+  id?: string,
+  children?: Node
+}
+type AxisTitleProps = {
+  children?: Node
+}
+
+function AxisTitle (props:AxisTitleProps) {
+
+}
+
+export function YAxis (props: AxisProps) {
+
+}
+YAxis.Title = AxisTitle;
+
+export function XAxis (props: AxisProps) {
+
+}
+XAxis.Title = AxisTitle;
+
+export class ZAxis extends React.Component<AxisProps> { }
+
+// this probable needs some refinement
+type DataType = Array<any>
+
+type SeriesProps = {
+  id?: string,
+  data?: DataType,
+  visible?: boolean,
+  children?: Node,
+  className?: string
+}
+export class AreaRangeSeries extends React.Component<SeriesProps> { }
+export class AreaSeries extends React.Component<SeriesProps> { }
+export class AreaSplineRangeSeries extends React.Component<SeriesProps> { }
+export class AreaSplineSeries extends React.Component<SeriesProps> { }
+
+export function BarSeries (props: SeriesProps) { }
+export class BoxPlotSeries extends React.Component<SeriesProps> { }
+export class BubbleSeries extends React.Component<SeriesProps> { }
+export class ColumnRangeSeries extends React.Component<SeriesProps> { }
+export class ColumnSeries extends React.Component<SeriesProps> { }
+export class ErrorBarSeries extends React.Component<SeriesProps> { }
+export class FunnelSeries extends React.Component<SeriesProps> { }
+export class LineSeries extends React.Component<SeriesProps> { }
+export class PieSeries extends React.Component<SeriesProps> { }
+export class PolygonSeries extends React.Component<SeriesProps> { }
+export class PyramidSeries extends React.Component<SeriesProps> { }
+export class SankeySeries extends React.Component<SeriesProps> { }
+export class ScatterSeries extends React.Component<SeriesProps> { }
+export class SplineSeries extends React.Component<SeriesProps> { }
+export class StreamGraphSeries extends React.Component<SeriesProps> { }
+export class TreemapSeries extends React.Component<SeriesProps> { }
+export class WaterfallSeries extends React.Component<SeriesProps> { }
+
+export function withHighcharts (Component: ComponentType<*>, Highcharts: HighchartsType) { }

--- a/packages/react-jsx-highcharts/src/index.js.flow
+++ b/packages/react-jsx-highcharts/src/index.js.flow
@@ -7,6 +7,7 @@ import type HighchartsType from 'highcharts';
 type HighchartsChartProps = {
   children?: Node
 }
+type Id = string | () => string;
 
 export function HighchartsChart(props: HighchartsChartProps) { }
 
@@ -77,7 +78,7 @@ export function Legend (props: LegendProps) {
 Legend.Title = LegendTitle;
 
 type PlotBandProps = {
-  id?: string,
+  id?: Id,
   from: any,
   to: any,
   color?: string,
@@ -92,7 +93,7 @@ export function PlotBand(props: PlotBandProps) {
 PlotBand.Label = PlotBandLabel;
 
 type PlotLineProps = {
-  id?: string,
+  id?: Id,
   value: any,
   color?: string,
 }
@@ -123,7 +124,7 @@ export function Tooltip (props:TooltipProps) { }
 
 type AxisProps = {
   type?: 'category' | 'linear' | 'logarithmic' | 'datetime',
-  id?: string,
+  id?: Id,
   children?: Node
 }
 type AxisTitleProps = {
@@ -150,12 +151,19 @@ export class ZAxis extends React.Component<AxisProps> { }
 type DataType = Array<any>
 
 type SeriesProps = {
-  id?: string,
+  id?: Id,
   data?: DataType,
   visible?: boolean,
   children?: Node,
   className?: string
 }
+
+type BaseSeriesProps = {
+  type: string
+} & SeriesProps
+
+export function Series (props: BaseSeriesProps) { }
+
 export class AreaRangeSeries extends React.Component<SeriesProps> { }
 export class AreaSeries extends React.Component<SeriesProps> { }
 export class AreaSplineRangeSeries extends React.Component<SeriesProps> { }

--- a/packages/react-jsx-highcharts/test/flow-types/index.js.flow
+++ b/packages/react-jsx-highcharts/test/flow-types/index.js.flow
@@ -16,7 +16,9 @@ import {
   HighchartsSparkline,
   ScatterSeries,
   BarSeries,
-  PlotBand
+  PlotBand,
+  Series,
+  SankeySeries
 } from "../../src";
 
 //$ExpectError
@@ -79,4 +81,15 @@ export const ScatterSeriesExample = () => {
 export const FailXAxis = () => {
   //$ExpectError
   return <XAxis id={1} />;
+}
+
+export const BaseSeriesFail = () => {
+  //$ExpectError
+  return <Series type={1} />;
+}
+const idFunction = () => {
+  return "" + Math.floor(Math.random() * (1000))
+}
+export const SeriesWithFunctionId = () => {
+  return <SankeySeries id={ idFunction } />;
 }

--- a/packages/react-jsx-highcharts/test/flow-types/index.js.flow
+++ b/packages/react-jsx-highcharts/test/flow-types/index.js.flow
@@ -1,0 +1,82 @@
+/* @flow */
+
+import React from "react";
+import Highcharts from "highcharts";
+import {
+  withHighcharts,
+  HighchartsChart,
+  Chart,
+  Title,
+  Subtitle,
+  Legend,
+  XAxis,
+  YAxis,
+  LineSeries,
+  PlotLine,
+  HighchartsSparkline,
+  ScatterSeries,
+  BarSeries,
+  PlotBand
+} from "../../src";
+
+//$ExpectError
+withHighcharts(1, Highcharts);
+
+const StatelessComponent = props => {
+  return "";
+};
+
+withHighcharts(StatelessComponent, Highcharts);
+
+
+class Example extends React.Component<*> {
+  render() {
+    return (
+      <div>
+        <HighchartsChart>
+          <Chart />
+
+          <Title>Solar Employment Growth by Sector, 2010-2016</Title>
+
+          <Subtitle>Source: thesolarfoundation.com</Subtitle>
+
+          <Legend layout="vertical" align="right" verticalAlign="middle">
+            <Legend.Title>legend</Legend.Title>
+          </Legend>
+
+          <XAxis>
+            <XAxis.Title>Time</XAxis.Title>
+            <PlotLine value={50000}>
+              <PlotLine.Label>PlotLine</PlotLine.Label>
+            </PlotLine>
+            <PlotBand from={40000} to={45000}>
+              <PlotBand.Label>PlotLine</PlotBand.Label>
+            </PlotBand>
+          </XAxis>
+
+          <YAxis>
+            <YAxis.Title>Number of employees</YAxis.Title>
+            <LineSeries name="Installation" data={[43934, 52503, 57177, 69658, 97031, 119931, 137133, 154175]} />
+            <LineSeries name="Manufacturing" data={[24916, 24064, 29742, 29851, 32490, 30282, 38121, 40434]} />
+            <LineSeries name="Sales & Distribution" data={[11744, 17722, 16005, 19771, 20185, 24377, 32147, 39387]} />
+            <LineSeries name="Project Development" data={[null, null, 7988, 12169, 15112, 22452, 34400, 34227]} />
+            <BarSeries name="Other" data={[12908, 5948, 8105, 11248, 8989, 11816, 18274, 18111]} />
+          </YAxis>
+        </HighchartsChart>
+        <HighchartsSparkline>
+
+        </HighchartsSparkline>
+      </div>
+    );
+  }
+}
+export const ExampleExport = withHighcharts(Example, Highcharts);
+
+
+export const ScatterSeriesExample = () => {
+  return <ScatterSeries id="myscatter" data={[null, { id: 1}, 1]}/>;
+}
+export const FailXAxis = () => {
+  //$ExpectError
+  return <XAxis id={1} />;
+}


### PR DESCRIPTION
This adds flow typings for library consumers.

build and test scripts are modified:
- build:prod builds all targets now
- test runs mocha and tests flow types with test file under /test/flow-types

I'm pretty sure there are some problems, but I'd like somebody else to try it out as it is easier to find bugs that way.

Simplest way to try it out:
- edit test/flow-types/index.js.flow
- npm run test:flow
