### PR TITLE
Fix cannot set state on unmounted component

### DIFF
--- a/packages/react-jsx-highcharts/src/components/DelayRender/DelayRender.js
+++ b/packages/react-jsx-highcharts/src/components/DelayRender/DelayRender.js
@@ -4,13 +4,20 @@ class DelayRender extends Component {
   state = {
     render: false
   }
+  renderTimeout = null;
 
   componentDidMount () {
-    window.setTimeout(() => {
+    this.renderTimeout = window.setTimeout(() => {
       this.setState({
         render: true
-      })
+      });
+      this.renderTimeout = null;
     }, 1);
+  }
+  componentWillUnmount() {
+    if(this.renderTimeout !== null) {
+      window.clearTimeout(this.renderTimeout);
+    }
   }
   render () {
     if (!this.state.render) return null;


### PR DESCRIPTION
Managed to run into this.

If axis is unmounted too quickly, React gives a warning:
"Can't call setState (or forceUpdate) on an unmounted component. This is a no-op, but it indicates a memory leak in your application. To fix, cancel all subscriptions and asynchronous tasks in the componentWillUnmount method."

In reality the warning tells that there is something wrong in my own code, but here's a fix anyway.


