### PR TITLE
Remove height rule that breaks examples on Firefox

### DIFF
--- a/examples/index.css
+++ b/examples/index.css
@@ -1,5 +1,4 @@
 #root {
-  height: 100vh;
   display: flex;
   align-items: center;
   justify-content: center;


### PR DESCRIPTION
The rule breaks the examples documentation page.

With the rule, the examples show like this

![image](https://user-images.githubusercontent.com/4683867/47102484-cfb9e900-d234-11e8-9c37-1558e1c8eed1.png)


Without the rule

![image](https://user-images.githubusercontent.com/4683867/47102528-e9f3c700-d234-11e8-9b17-5fc6e6abbf01.png)
