### PR TITLE
Redraw only once on mount, remove forced updates

### DIFF
--- a/packages/react-jsx-highcharts/src/components/Axis/Axis.js
+++ b/packages/react-jsx-highcharts/src/components/Axis/Axis.js
@@ -60,27 +60,29 @@ class Axis extends Component {
     }
   }
 
-  render () {
-    if (!this.axis) {
-      const { id, dynamicAxis, isX, getChart } = this.props;
-      const chart = getChart();
+  createAxis () {
+    const { id, dynamicAxis, isX, getChart } = this.props;
+    const chart = getChart();
 
-      // Create Highcharts Axis
-      const opts = this.getAxisConfig();
-      if (dynamicAxis) {
-        this.axis = chart.addAxis(opts, isX, false);
-      } else {
-        // ZAxis cannot be added dynamically, Maps only have a single axes - update instead
-        const axisId = isFunction(id) ? id() : id
-        this.axis = chart.get(axisId);
-        this.axis.update(opts, false);
-      }
-
-      const update = this.axis.update.bind(this.axis);
-
-      // we rely addEventProps to call redraw
-      addEventProps(update, this.props, true);
+    // Create Highcharts Axis
+    const opts = this.getAxisConfig();
+    if (dynamicAxis) {
+      this.axis = chart.addAxis(opts, isX, false);
+    } else {
+      // ZAxis cannot be added dynamically, Maps only have a single axes - update instead
+      const axisId = isFunction(id) ? id() : id
+      this.axis = chart.get(axisId);
+      this.axis.update(opts, false);
     }
+
+    const update = this.axis.update.bind(this.axis);
+
+    // we rely addEventProps to call redraw
+    addEventProps(update, this.props, true);
+  }
+
+  render () {
+    if (!this.axis) this.createAxis();
 
     return (
       <Provider value={this.axis}>

--- a/packages/react-jsx-highcharts/src/components/Axis/Axis.js
+++ b/packages/react-jsx-highcharts/src/components/Axis/Axis.js
@@ -34,28 +34,6 @@ class Axis extends Component {
     }
   }
 
-  componentDidMount () {
-    const { id, dynamicAxis, isX, getChart } = this.props;
-    const chart = getChart();
-
-    // Create Highcharts Axis
-    const opts = this.getAxisConfig();
-    if (dynamicAxis) {
-      this.axis = chart.addAxis(opts, isX, true);
-    } else {
-      // ZAxis cannot be added dynamically, Maps only have a single axes - update instead
-      const axisId = isFunction(id) ? id() : id
-      this.axis = chart.get(axisId);
-      this.axis.update(opts, true);
-    }
-
-    const update = this.axis.update.bind(this.axis)
-    addEventProps(update, this.props);
-
-    // Re-render to pass this.axis to Provider
-    this.forceUpdate();
-  }
-
   componentDidUpdate (prevProps) {
     const modifiedProps = getModifiedProps(prevProps, this.props);
     if (modifiedProps !== false) {
@@ -83,7 +61,26 @@ class Axis extends Component {
   }
 
   render () {
-    if (!this.axis) return null;
+    if (!this.axis) {
+      const { id, dynamicAxis, isX, getChart } = this.props;
+      const chart = getChart();
+
+      // Create Highcharts Axis
+      const opts = this.getAxisConfig();
+      if (dynamicAxis) {
+        this.axis = chart.addAxis(opts, isX, false);
+      } else {
+        // ZAxis cannot be added dynamically, Maps only have a single axes - update instead
+        const axisId = isFunction(id) ? id() : id
+        this.axis = chart.get(axisId);
+        this.axis.update(opts, false);
+      }
+
+      const update = this.axis.update.bind(this.axis);
+
+      // we rely addEventProps to call redraw
+      addEventProps(update, this.props, true);
+    }
 
     return (
       <Provider value={this.axis}>

--- a/packages/react-jsx-highcharts/src/components/Axis/Axis.js
+++ b/packages/react-jsx-highcharts/src/components/Axis/Axis.js
@@ -60,7 +60,7 @@ class Axis extends Component {
     }
   }
 
-  createAxis () {
+  createAxis = () => {
     const { id, dynamicAxis, isX, getChart } = this.props;
     const chart = getChart();
 

--- a/packages/react-jsx-highcharts/src/components/Series/Series.js
+++ b/packages/react-jsx-highcharts/src/components/Series/Series.js
@@ -88,19 +88,21 @@ class Series extends Component {
     return config;
   }
 
+  createSeries () {
+    const chart = this.props.getChart();
+
+    // Create Highcharts Series
+    const opts = this.getSeriesConfig();
+    this.series = chart.addSeries(opts, false);
+
+    const update = this.series.update.bind(this.series);
+
+    // we rely addEventProps to call redraw
+    addEventProps(update, this.props, true);
+  }
+
   render () {
-    if (!this.series) {
-      const chart = this.props.getChart();
-
-      // Create Highcharts Series
-      const opts = this.getSeriesConfig();
-      this.series = chart.addSeries(opts, false);
-
-      const update = this.series.update.bind(this.series);
-
-      // we rely addEventProps to call redraw
-      addEventProps(update, this.props, true);
-    }
+    if (!this.series) this.createSeries();
 
     return (
       <Provider value={this.series}>

--- a/packages/react-jsx-highcharts/src/components/Series/Series.js
+++ b/packages/react-jsx-highcharts/src/components/Series/Series.js
@@ -41,20 +41,6 @@ class Series extends Component {
     }
   }
 
-  componentDidMount () {
-    const chart = this.props.getChart();
-
-    // Create Highcharts Series
-    const opts = this.getSeriesConfig();
-    this.series = chart.addSeries(opts, true);
-
-    const update = this.series.update.bind(this.series)
-    addEventProps(update, this.props);
-
-    // Re-render to pass this.series to Provider
-    this.forceUpdate();
-  }
-
   componentDidUpdate (prevProps) {
     const { visible, data, ...rest } = this.props;
 
@@ -103,7 +89,18 @@ class Series extends Component {
   }
 
   render () {
-    if (!this.series) return null;
+    if (!this.series) {
+      const chart = this.props.getChart();
+
+      // Create Highcharts Series
+      const opts = this.getSeriesConfig();
+      this.series = chart.addSeries(opts, false);
+
+      const update = this.series.update.bind(this.series);
+
+      // we rely addEventProps to call redraw
+      addEventProps(update, this.props, true);
+    }
 
     return (
       <Provider value={this.series}>

--- a/packages/react-jsx-highcharts/src/components/Series/Series.js
+++ b/packages/react-jsx-highcharts/src/components/Series/Series.js
@@ -88,7 +88,7 @@ class Series extends Component {
     return config;
   }
 
-  createSeries () {
+  createSeries = () => {
     const chart = this.props.getChart();
 
     // Create Highcharts Series

--- a/packages/react-jsx-highcharts/src/utils/events.js
+++ b/packages/react-jsx-highcharts/src/utils/events.js
@@ -29,9 +29,9 @@ export const addEventHandlersManually = (Highcharts, context, props) => {
   });
 };
 
-export const addEventHandlers = (updateFn, props) => {
+export const addEventHandlers = (updateFn, props, redraw = true) => {
   const events = getEventsConfig(props);
-  updateFn({ events });
+  updateFn({ events }, redraw);
 };
 
 const _isEventKey = (value, key) => (key.indexOf('on') === 0) && isFunction(value);

--- a/packages/react-jsx-highcharts/test/components/Axis/Axis.spec.js
+++ b/packages/react-jsx-highcharts/test/components/Axis/Axis.spec.js
@@ -25,14 +25,14 @@ describe('<Axis />', () => {
     it('adds an X axis using the addAxis method', () => {
       mount(<Axis id="myAxis" isX {...testContext.propsFromProviders} />);
       expect(testContext.chartStubs.addAxis).toHaveBeenCalledWith(
-        expect.objectContaining({ id: 'myAxis', title: { text: null } }), true, true
+        expect.objectContaining({ id: 'myAxis', title: { text: null } }), true, false
       );
     });
 
     it('adds a Y axis using the addAxis method', () => {
       mount(<Axis id="myAxis" isX={false} {...testContext.propsFromProviders} />);
       expect(testContext.chartStubs.addAxis).toHaveBeenCalledWith(
-        expect.objectContaining({ id: 'myAxis', title: { text: null } }), false, true
+        expect.objectContaining({ id: 'myAxis', title: { text: null } }), false, false
       );
     });
 
@@ -61,7 +61,7 @@ describe('<Axis />', () => {
     it('should pass additional props through to Highcharts addAxis method', () => {
       mount(<Axis id="myAxis" isX min={10} max={100} reversed {...testContext.propsFromProviders} />);
       expect(testContext.chartStubs.addAxis).toHaveBeenCalledWith(
-        expect.objectContaining({ id: 'myAxis', title: { text: null }, min: 10, max: 100, reversed: true }), true, true
+        expect.objectContaining({ id: 'myAxis', title: { text: null }, min: 10, max: 100, reversed: true }), true, false
       );
     });
 
@@ -78,7 +78,7 @@ describe('<Axis />', () => {
           setExtremes: handleSetExtremes,
           afterSetExtremes: handleAfterSetExtremes
         })
-      });
+      }, true);
     });
   });
 
@@ -96,14 +96,14 @@ describe('<Axis />', () => {
       mount(<Axis id="myAxis" isX={false} dynamicAxis={false} {...testContext.propsFromProviders} />);
       expect(testContext.axisStubs.update).toHaveBeenCalledWith(expect.objectContaining(
         { id: 'myAxis', title: { text: null } }, true
-      ), expect.any(Boolean));
+      ), false);
     });
 
     it('should pass additional props through to Highcharts update method', () => {
       mount(<Axis id="myAxis" isX={false} dynamicAxis={false} min={10} max={100} reversed {...testContext.propsFromProviders} />);
       expect(testContext.axisStubs.update).toHaveBeenCalledWith(expect.objectContaining(
         { id: 'myAxis', title: { text: null }, min: 10, max: 100, reversed: true }, true
-      ), expect.any(Boolean));
+      ), false);
     });
 
     it('subscribes to Highcharts events for props that look like event handlers', () => {
@@ -119,7 +119,7 @@ describe('<Axis />', () => {
           setExtremes: handleSetExtremes,
           afterSetExtremes: handleAfterSetExtremes
         })
-      });
+      }, true);
     });
   });
 

--- a/packages/react-jsx-highcharts/test/components/Series/Series.spec.js
+++ b/packages/react-jsx-highcharts/test/components/Series/Series.spec.js
@@ -35,7 +35,7 @@ describe('<Series />', () => {
       );
       expect(testContext.chartStubs.addSeries).toHaveBeenCalledWith(expect.objectContaining(
         { id: 'mySeries', xAxis: 'myXAxisId', type: 'line', data: [], visible: true }, true
-      ), true);
+      ), false);
     });
 
     it('adds a Y series using the addSeries method', () => {
@@ -47,7 +47,7 @@ describe('<Series />', () => {
       );
       expect(testContext.chartStubs.addSeries).toHaveBeenCalledWith(expect.objectContaining(
         { id: 'mySeries', yAxis: 'myYAxisId', type: 'line', data: [], visible: true }, true
-      ), true);
+      ), false);
     });
 
     it('uses the provided ID if id prop is a string', () => {
@@ -78,7 +78,7 @@ describe('<Series />', () => {
       );
       expect(testContext.chartStubs.addSeries).toHaveBeenCalledWith(expect.objectContaining({
         id: 'mySeries', yAxis: 'myAxis', type: 'line', data: [5], visible: true, step: true
-      }), true);
+      }), false);
     });
 
     it('subscribes to Highcharts events for props that look like event handlers', () => {
@@ -94,7 +94,7 @@ describe('<Series />', () => {
           click: handleClick,
           show: handleShow
         }
-      });
+      }, true);
     });
 
     it('supports mounting with Immutable List data', () => {
@@ -104,7 +104,7 @@ describe('<Series />', () => {
       );
       expect(testContext.chartStubs.addSeries).toHaveBeenCalledWith(expect.objectContaining(
         { id: 'mySeries', yAxis: 'myAxis', type: 'line', data, visible: true }
-      ), true);
+      ), false);
     });
   });
 

--- a/packages/react-jsx-highcharts/test/utils/events.spec.js
+++ b/packages/react-jsx-highcharts/test/utils/events.spec.js
@@ -92,7 +92,7 @@ describe('utils/events', () => {
           eventHandler: onEventHandler,
           otherEventHandler: onOtherEventHandler
         }
-      });
+      }, true);
     });
   });
 });


### PR DESCRIPTION
This saves a couple of unnecessary redraw calls when adding axis or series. I found the calls while doing profiling.

It does it by chart.addAxis and chart.addSeries calls to have redraw = false. Then it relies on the last call to addEventProps to call updateFn with redraw = true.

Also this treats render() as lifecycle method so that Axis and Series don't need to call this.forceUpdate.