### PR TITLE
Add eventhandlers to Axis and Series when they are created

### DIFF
--- a/packages/react-jsx-highcharts/src/components/Axis/Axis.js
+++ b/packages/react-jsx-highcharts/src/components/Axis/Axis.js
@@ -4,7 +4,7 @@ import uuid from 'uuid/v4';
 import { isFunction } from 'lodash-es';
 import { attempt } from 'lodash-es';
 import { Provider } from '../AxisContext';
-import addEventProps, { getNonEventHandlerProps } from '../../utils/events';
+import { getNonEventHandlerProps, getEventsConfig } from '../../utils/events';
 import getModifiedProps from '../../utils/getModifiedProps';
 import { validAxisTypes } from '../../utils/propTypeValidators';
 import { logZAxisErrorMessage } from '../../utils/warnings'
@@ -60,9 +60,12 @@ class Axis extends Component {
 
     const axisId = isFunction(id) ? id() : id
     const nonEventProps = getNonEventHandlerProps(rest);
+    const events = getEventsConfig(rest);
+
     return {
       id: axisId,
       title: { text: null },
+      events,
       ...nonEventProps
     }
   }
@@ -81,10 +84,6 @@ class Axis extends Component {
       this.axis = chart.get(axisId);
       this.axis.update(opts, false);
     }
-
-    const update = this.axis.update.bind(this.axis);
-
-    addEventProps(update, this.props, false);
   }
 
   render () {

--- a/packages/react-jsx-highcharts/src/components/Series/Series.js
+++ b/packages/react-jsx-highcharts/src/components/Series/Series.js
@@ -109,13 +109,7 @@ class Series extends Component {
     // Create Highcharts Series
     const opts = this.getSeriesConfig();
 
-    /* a hack to make sankey series work
-    for details: https://github.com/highcharts/highcharts/issues/9300
-    remove if fixed in highcharts
-    */
-    let redrawOnAdd = this.props.type === 'sankey';
-
-    this.series = chart.addSeries(opts, redrawOnAdd);
+    this.series = chart.addSeries(opts, false);
   }
 
   render () {

--- a/packages/react-jsx-highcharts/src/components/Series/Series.js
+++ b/packages/react-jsx-highcharts/src/components/Series/Series.js
@@ -7,7 +7,7 @@ import { attempt } from 'lodash-es';
 import isImmutable from 'is-immutable';
 import immutableEqual from 'immutable-is';
 import { Provider } from '../SeriesContext';
-import addEventProps, { getNonEventHandlerProps } from '../../utils/events';
+import { getNonEventHandlerProps, getEventsConfig } from '../../utils/events';
 import getModifiedProps from '../../utils/getModifiedProps';
 import { logSeriesErrorMessage } from '../../utils/warnings';
 
@@ -86,10 +86,12 @@ class Series extends Component {
     const seriesId = isFunction(id) ? id() : id
     const seriesData = isImmutable(data) ? data.toJS() : data;
     const nonEventProps = getNonEventHandlerProps(rest);
+    const events = getEventsConfig(rest);
 
     const config = {
       id: seriesId,
       data: seriesData,
+      events,
       ...nonEventProps
     }
 
@@ -114,10 +116,6 @@ class Series extends Component {
     let redrawOnAdd = this.props.type === 'sankey';
 
     this.series = chart.addSeries(opts, redrawOnAdd);
-
-    const update = this.series.update.bind(this.series);
-
-    addEventProps(update, this.props, false);
   }
 
   render () {

--- a/packages/react-jsx-highcharts/test/components/Axis/Axis.spec.js
+++ b/packages/react-jsx-highcharts/test/components/Axis/Axis.spec.js
@@ -76,12 +76,12 @@ describe('<Axis />', () => {
         <Axis id="myAxis" isX onSetExtremes={handleSetExtremes} onAfterSetExtremes={handleAfterSetExtremes}
           {...testContext.propsFromProviders} />
       );
-      expect(testContext.axisStubs.update).toHaveBeenCalledWith({
+      expect(testContext.chartStubs.addAxis).toHaveBeenCalledWith(expect.objectContaining({
         events: expect.objectContaining({
           setExtremes: handleSetExtremes,
           afterSetExtremes: handleAfterSetExtremes
         })
-      }, false);
+      }), true, false);
       expect(testContext.propsFromProviders.needsRedraw).toHaveBeenCalledTimes(1);
     });
   });
@@ -118,12 +118,12 @@ describe('<Axis />', () => {
         <Axis id="myAxis" isX={false} dynamicAxis={false} onSetExtremes={handleSetExtremes} onAfterSetExtremes={handleAfterSetExtremes}
           {...testContext.propsFromProviders} />
       );
-      expect(testContext.axisStubs.update).toHaveBeenCalledWith({
+      expect(testContext.axisStubs.update).toHaveBeenCalledWith(expect.objectContaining({
         events: expect.objectContaining({
           setExtremes: handleSetExtremes,
           afterSetExtremes: handleAfterSetExtremes
         })
-      }, false);
+      }), false);
     });
   });
 

--- a/packages/react-jsx-highcharts/test/components/Series/Series.spec.js
+++ b/packages/react-jsx-highcharts/test/components/Series/Series.spec.js
@@ -92,12 +92,12 @@ describe('<Series />', () => {
         <Series id="mySeries" onClick={handleClick} onShow={handleShow}
           {...testContext.propsFromProviders} />
       );
-      expect(testContext.seriesStubs.update).toHaveBeenCalledWith({
+      expect(testContext.chartStubs.addSeries).toHaveBeenCalledWith(expect.objectContaining({
         events: {
           click: handleClick,
           show: handleShow
         }
-      }, false);
+      }), false);
     });
 
     it('supports mounting with Immutable List data', () => {

--- a/packages/react-jsx-highcharts/test/components/Series/SeriesTypes.spec.js
+++ b/packages/react-jsx-highcharts/test/components/Series/SeriesTypes.spec.js
@@ -80,6 +80,31 @@ Object.keys(all).filter(name => /^[A-Z].*Series$/.test(name)).forEach((seriesNam
         const WithComponent = withHighcharts(Component, Highcharts);
         const renderedChart = renderIntoDocument(<WithComponent />);
       });
+      it('binds hide event correctly', (done) => {
+        const afterAddSeries = (event) => {
+          expect(event.target.series[0].visible).toBe(true);
+          event.target.series[0].hide();
+        }
+        const onHide = (event) => {
+          expect(event.target.visible).toBe(false);
+          done();
+        }
+        const Component = (props) => {
+          return (
+            <HighchartsChart>
+              <Chart zoomType="x" onAfterAddSeries={afterAddSeries}/>
+              <XAxis>
+              </XAxis>
+              <YAxis>
+                <SeriesComponent data={[1,2,3,4]} onHide={ onHide }/>
+              </YAxis>
+            </HighchartsChart>
+          )
+        };
+        const WithComponent = withHighcharts(Component, Highcharts);
+        const renderedChart = renderIntoDocument(<WithComponent />);
+
+      });
     }
   });
 });


### PR DESCRIPTION
It's pretty straight forward, but I don't know the history of adding the event handlers with update, so decided to ask for review.

And this is not urgent by any means.

edit: it also seems to fix sankey series problem, removed the hack for it