### PR TITLE
Add eslint-plugin-react-perf and fix errors

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,7 +1,7 @@
 {
   "root": true,
   "parser": "babel-eslint",
-  "plugins": ["react", "import"],
+  "plugins": ["react", "import", "react-perf"],
   "parserOptions": {
     "ecmaVersion": 2018,
     "sourceType": "module",
@@ -16,7 +16,8 @@
   "extends": [
     "eslint:recommended",
     "plugin:react/recommended",
-    "plugin:import/errors"
+    "plugin:import/errors",
+    "plugin:react-perf/recommended"
   ],
   "rules": {
     "no-unused-vars": [

--- a/packages/react-jsx-highcharts/package-lock.json
+++ b/packages/react-jsx-highcharts/package-lock.json
@@ -3319,6 +3319,12 @@
         }
       }
     },
+    "eslint-plugin-react-perf": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-perf/-/eslint-plugin-react-perf-3.2.0.tgz",
+      "integrity": "sha512-PnAsJPwCmoI4CBtF/Uk0v1dN4zvpWC3fO5BzG9O+q/c+6hXv9cFzgXht+CJzZaC61VuYBpjWdOs9ksBN6Py1iw==",
+      "dev": true
+    },
     "eslint-scope": {
       "version": "3.7.1",
       "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-3.7.1.tgz",

--- a/packages/react-jsx-highcharts/package-lock.json
+++ b/packages/react-jsx-highcharts/package-lock.json
@@ -6159,6 +6159,11 @@
         }
       }
     },
+    "memoize-one": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.1.1.tgz",
+      "integrity": "sha512-HKeeBpWvqiVJD57ZUAsJNm71eHTykffzcLZVYWiVfQeI1rJtuEaS7hQiEpWfVVk18donPwJEcFKIkCmPJNOhHA=="
+    },
     "memory-fs": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.4.1.tgz",

--- a/packages/react-jsx-highcharts/package.json
+++ b/packages/react-jsx-highcharts/package.json
@@ -73,6 +73,7 @@
     "eslint": "^5.16.0",
     "eslint-plugin-import": "^2.18.2",
     "eslint-plugin-react": "^7.14.2",
+    "eslint-plugin-react-perf": "^3.2.0",
     "highcharts": "^7.1.2",
     "immutable": "^4.0.0-0",
     "immutable3": "npm:immutable@^3.8.1",

--- a/packages/react-jsx-highcharts/package.json
+++ b/packages/react-jsx-highcharts/package.json
@@ -93,6 +93,7 @@
     "immutable-is": "^3.7.6",
     "is-immutable": "^1.0.1",
     "lodash-es": "^4.17.13",
+    "memoize-one": "^5.1.1",
     "mini-create-react-context": "^0.3.2",
     "uuid": "^3.2.1"
   },

--- a/packages/react-jsx-highcharts/src/components/AxisProvider/index.js
+++ b/packages/react-jsx-highcharts/src/components/AxisProvider/index.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { defaultTo } from 'lodash-es';
+import memoizeOne from 'memoize-one';
 import DelayRender from '../DelayRender';
 import provideChart from '../ChartProvider';
 import { Consumer } from '../AxisContext';
@@ -9,6 +10,24 @@ import clean from '../../utils/removeProvidedProps';
 // This is a HOC function.
 // It takes a component...
 export default function provideAxis(Component) {
+
+  const createGetAxis = memoizeOne((axis) => {
+    return () => ({
+      object: axis,
+      id: axis.userOptions && axis.userOptions.id,
+      type: axis.coll,
+      update: clean(axis.update.bind(axis)),
+      remove: axis.remove.bind(axis),
+      addPlotBand: clean(axis.addPlotBand.bind(axis)),
+      removePlotBand: axis.removePlotBand.bind(axis),
+      addPlotLine: clean(axis.addPlotLine.bind(axis)),
+      removePlotLine: axis.removePlotLine.bind(axis),
+      getExtremes: axis.getExtremes.bind(axis),
+      setExtremes: axis.setExtremes.bind(axis),
+      setTitle: clean(axis.setTitle.bind(axis))
+    });
+  });
+
   // ...and returns another component...
   const AxisWrappedComponent = function(props) {
     // ... and renders the wrapped component with the context axis
@@ -26,20 +45,7 @@ export default function provideAxis(Component) {
             // Some series (such as Pie and Funnel don't require an axis)
             if (!axis && requiresAxis) return null;
 
-            const getAxis = () => ({
-              object: axis,
-              id: axis.userOptions && axis.userOptions.id,
-              type: axis.coll,
-              update: clean(axis.update.bind(axis)),
-              remove: axis.remove.bind(axis),
-              addPlotBand: clean(axis.addPlotBand.bind(axis)),
-              removePlotBand: axis.removePlotBand.bind(axis),
-              addPlotLine: clean(axis.addPlotLine.bind(axis)),
-              removePlotLine: axis.removePlotLine.bind(axis),
-              getExtremes: axis.getExtremes.bind(axis),
-              setExtremes: axis.setExtremes.bind(axis),
-              setTitle: clean(axis.setTitle.bind(axis))
-            })
+            const getAxis = createGetAxis(axis);
 
             return (
               <Component

--- a/packages/react-jsx-highcharts/src/components/AxisProvider/index.js
+++ b/packages/react-jsx-highcharts/src/components/AxisProvider/index.js
@@ -11,22 +11,20 @@ import clean from '../../utils/removeProvidedProps';
 // It takes a component...
 export default function provideAxis(Component) {
 
-  const createGetAxis = memoizeOne((axis) => {
-    return () => ({
-      object: axis,
-      id: axis.userOptions && axis.userOptions.id,
-      type: axis.coll,
-      update: clean(axis.update.bind(axis)),
-      remove: axis.remove.bind(axis),
-      addPlotBand: clean(axis.addPlotBand.bind(axis)),
-      removePlotBand: axis.removePlotBand.bind(axis),
-      addPlotLine: clean(axis.addPlotLine.bind(axis)),
-      removePlotLine: axis.removePlotLine.bind(axis),
-      getExtremes: axis.getExtremes.bind(axis),
-      setExtremes: axis.setExtremes.bind(axis),
-      setTitle: clean(axis.setTitle.bind(axis))
-    });
-  });
+  const createGetAxis = memoizeOne(axis => () => ({
+    object: axis,
+    id: axis.userOptions && axis.userOptions.id,
+    type: axis.coll,
+    update: clean(axis.update.bind(axis)),
+    remove: axis.remove.bind(axis),
+    addPlotBand: clean(axis.addPlotBand.bind(axis)),
+    removePlotBand: axis.removePlotBand.bind(axis),
+    addPlotLine: clean(axis.addPlotLine.bind(axis)),
+    removePlotLine: axis.removePlotLine.bind(axis),
+    getExtremes: axis.getExtremes.bind(axis),
+    setExtremes: axis.setExtremes.bind(axis),
+    setTitle: clean(axis.setTitle.bind(axis))
+  }));
 
   // ...and returns another component...
   const AxisWrappedComponent = function(props) {

--- a/packages/react-jsx-highcharts/src/components/BaseChart/BaseChart.js
+++ b/packages/react-jsx-highcharts/src/components/BaseChart/BaseChart.js
@@ -1,5 +1,6 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
+import memoizeOne from 'memoize-one';
 import debounce from '../../utils/debounce-raf';
 import { isEqual, attempt } from 'lodash-es'
 import { Provider } from '../ChartContext';
@@ -111,6 +112,10 @@ class BaseChart extends Component {
     }
   });
 
+  getProviderValue = memoizeOne((chart, chartType, needsRedraw ) => {
+    return { chart, chartType, needsRedraw };
+  })
+
   render () {
     const { chartType, children } = this.props;
 
@@ -119,7 +124,7 @@ class BaseChart extends Component {
         className={`chart ${this.props.className}`}
         ref={ this.setDomNode }>
         {this.state.rendered && (
-          <Provider value={{ chart: this.chart, chartType, needsRedraw: this.needsRedraw }}>
+          <Provider value={this.getProviderValue(this.chart, chartType, this.needsRedraw)}>
             {children}
           </Provider>
         )}

--- a/packages/react-jsx-highcharts/src/components/ChartProvider/index.js
+++ b/packages/react-jsx-highcharts/src/components/ChartProvider/index.js
@@ -9,23 +9,22 @@ import clean from '../../utils/removeProvidedProps';
 // It takes a component...
 export default function provideChart(Component) {
 
-  const createGetChart = memoizeOne((chart, chartType) => {
-    return () => ({
-      object: chart,
-      type: chartType,
-      get: chart.get.bind(chart),
-      setSize: chart.setSize.bind(chart),
-      update: clean(chart.update.bind(chart)),
-      addAxis: clean(chart.addAxis.bind(chart)),
-      addSeries: clean(chart.addSeries.bind(chart)),
-      setTitle: clean(chart.setTitle.bind(chart)),
-      showLoading: chart.showLoading.bind(chart),
-      hideLoading: chart.hideLoading.bind(chart),
-      addCredits: clean(chart.addCredits.bind(chart)),
-      addAnnotation: chart.addAnnotation ? clean(chart.addAnnotation.bind(chart)) : null,
-      removeAnnotation: chart.removeAnnotation ? chart.removeAnnotation.bind(chart) : null
-    })
-  })
+  const createGetChart = memoizeOne((chart, chartType) => () => ({
+    object: chart,
+    type: chartType,
+    get: chart.get.bind(chart),
+    setSize: chart.setSize.bind(chart),
+    update: clean(chart.update.bind(chart)),
+    addAxis: clean(chart.addAxis.bind(chart)),
+    addSeries: clean(chart.addSeries.bind(chart)),
+    setTitle: clean(chart.setTitle.bind(chart)),
+    showLoading: chart.showLoading.bind(chart),
+    hideLoading: chart.hideLoading.bind(chart),
+    addCredits: clean(chart.addCredits.bind(chart)),
+    addAnnotation: chart.addAnnotation ? clean(chart.addAnnotation.bind(chart)) : null,
+    removeAnnotation: chart.removeAnnotation ? chart.removeAnnotation.bind(chart) : null
+  }));
+
 
   // ...and returns another component...
   const ChartWrappedComponent = function(props) {

--- a/packages/react-jsx-highcharts/src/components/ChartProvider/index.js
+++ b/packages/react-jsx-highcharts/src/components/ChartProvider/index.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import memoizeOne from 'memoize-one';
 import { Consumer } from '../ChartContext';
 import provideHighcharts from '../HighchartsProvider'
 import getDisplayName from '../../utils/getDisplayName';
@@ -7,6 +8,25 @@ import clean from '../../utils/removeProvidedProps';
 // This is a HOC function.
 // It takes a component...
 export default function provideChart(Component) {
+
+  const createGetChart = memoizeOne((chart, chartType) => {
+    return () => ({
+      object: chart,
+      type: chartType,
+      get: chart.get.bind(chart),
+      setSize: chart.setSize.bind(chart),
+      update: clean(chart.update.bind(chart)),
+      addAxis: clean(chart.addAxis.bind(chart)),
+      addSeries: clean(chart.addSeries.bind(chart)),
+      setTitle: clean(chart.setTitle.bind(chart)),
+      showLoading: chart.showLoading.bind(chart),
+      hideLoading: chart.hideLoading.bind(chart),
+      addCredits: clean(chart.addCredits.bind(chart)),
+      addAnnotation: chart.addAnnotation ? clean(chart.addAnnotation.bind(chart)) : null,
+      removeAnnotation: chart.removeAnnotation ? chart.removeAnnotation.bind(chart) : null
+    })
+  })
+
   // ...and returns another component...
   const ChartWrappedComponent = function(props) {
     // ... and renders the wrapped component with the context chart
@@ -16,21 +36,7 @@ export default function provideChart(Component) {
         {({ chart, chartType, needsRedraw }) => {
           if (!chart) return null;
 
-          const getChart = () => ({
-            object: chart,
-            type: chartType,
-            get: chart.get.bind(chart),
-            setSize: chart.setSize.bind(chart),
-            update: clean(chart.update.bind(chart)),
-            addAxis: clean(chart.addAxis.bind(chart)),
-            addSeries: clean(chart.addSeries.bind(chart)),
-            setTitle: clean(chart.setTitle.bind(chart)),
-            showLoading: chart.showLoading.bind(chart),
-            hideLoading: chart.hideLoading.bind(chart),
-            addCredits: clean(chart.addCredits.bind(chart)),
-            addAnnotation: chart.addAnnotation ? clean(chart.addAnnotation.bind(chart)) : null,
-            removeAnnotation: chart.removeAnnotation ? chart.removeAnnotation.bind(chart) : null
-          })
+          const getChart = createGetChart(chart, chartType);
 
           return (
             <Component

--- a/packages/react-jsx-highcharts/src/components/Highcharts3dChart/Highcharts3dChart.js
+++ b/packages/react-jsx-highcharts/src/components/Highcharts3dChart/Highcharts3dChart.js
@@ -2,6 +2,13 @@ import React, { Component } from 'react';
 import HighchartsChart from '../HighchartsChart';
 import Options3d from '../Options3d';
 
+const CHART = {
+  options3d: { enabled: true }
+};
+const ZAXIS = {
+  id: 'zAxis'
+};
+
 class Highcharts3dChart extends Component {
 
   static propTypes = Options3d.propTypes;
@@ -11,15 +18,8 @@ class Highcharts3dChart extends Component {
       children, alpha, axisLabelPosition, beta, depth, fitToPlot, frame, viewDistance, ...rest
     } = this.props;
 
-    const chart = {
-      options3d: { enabled: true }
-    };
-    const zAxis = {
-      id: 'zAxis'
-    };
-
     return (
-      <HighchartsChart chart={chart} zAxis={zAxis} {...rest}>
+      <HighchartsChart chart={CHART} zAxis={ZAXIS} {...rest}>
         <Options3d
           alpha={alpha}
           axisLabelPosition={axisLabelPosition}

--- a/packages/react-jsx-highcharts/src/components/HighchartsProvider/index.js
+++ b/packages/react-jsx-highcharts/src/components/HighchartsProvider/index.js
@@ -7,9 +7,8 @@ import getDisplayName from '../../utils/getDisplayName';
 // It takes a component...
 export default function provideHighcharts(Component) {
 
-  const createGetHighcharts = memoizeOne((Highcharts) => {
-    return () => Highcharts;
-  })
+  const createGetHighcharts = memoizeOne(Highcharts => () => Highcharts);
+
   // ...and returns another component...
   const HighchartsWrappedComponent = function (props) {
     // ... and renders the wrapped component with the context Highcharts global

--- a/packages/react-jsx-highcharts/src/components/HighchartsProvider/index.js
+++ b/packages/react-jsx-highcharts/src/components/HighchartsProvider/index.js
@@ -1,10 +1,15 @@
 import React from 'react';
+import memoizeOne from 'memoize-one';
 import { Consumer } from '../HighchartsContext';
 import getDisplayName from '../../utils/getDisplayName';
 
 // This is a HOC function.
 // It takes a component...
 export default function provideHighcharts(Component) {
+
+  const createGetHighcharts = memoizeOne((Highcharts) => {
+    return () => Highcharts;
+  })
   // ...and returns another component...
   const HighchartsWrappedComponent = function (props) {
     // ... and renders the wrapped component with the context Highcharts global
@@ -12,7 +17,7 @@ export default function provideHighcharts(Component) {
     return (
       <Consumer>
         {Highcharts => (
-          <Component {...props} getHighcharts={() => Highcharts} />
+          <Component {...props} getHighcharts={createGetHighcharts(Highcharts)} />
         )}
       </Consumer>
     );

--- a/packages/react-jsx-highcharts/src/components/HighchartsSparkline/HighchartsSparkline.js
+++ b/packages/react-jsx-highcharts/src/components/HighchartsSparkline/HighchartsSparkline.js
@@ -28,6 +28,10 @@ const defaultSparklinePlotOptions = {
   }
 };
 
+const EMPTY_ARRAY = [];
+const ZERO_ARRAY = [0];
+const LABELS_DISABLED = { enabled: false };
+
 class HighchartsSparkline extends Component {
 
   static propTypes = {
@@ -68,9 +72,9 @@ class HighchartsSparkline extends Component {
           style={chartStyle}
           skipClone />
 
-        <XAxis labels={{ enabled: false }} startOnTick={false} endOnTick={false} tickPositions={[]} />
+        <XAxis labels={LABELS_DISABLED} startOnTick={false} endOnTick={false} tickPositions={EMPTY_ARRAY} />
 
-        <YAxis id="sparkline" labels={{ enabled: false }} startOnTick={false} endOnTick={false} tickPositions={[0]}>
+        <YAxis id="sparkline" labels={LABELS_DISABLED} startOnTick={false} endOnTick={false} tickPositions={ZERO_ARRAY}>
           {Series}
         </YAxis>
 

--- a/packages/react-jsx-highcharts/src/components/HighchartsSparkline/HighchartsSparkline.js
+++ b/packages/react-jsx-highcharts/src/components/HighchartsSparkline/HighchartsSparkline.js
@@ -1,5 +1,6 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
+import memoizeOne from 'memoize-one';
 import HighchartsChart from '../HighchartsChart';
 import Chart from '../Chart';
 import XAxis from '../XAxis';
@@ -52,10 +53,14 @@ class HighchartsSparkline extends Component {
     plotOptions: defaultSparklinePlotOptions
   };
 
+  getChartStyle = memoizeOne((style) => {
+    return { overflow: 'visible', ...style };
+  })
+
   render () {
     const { height, width, margin, style, series, children, ...rest } = this.props;
     const hasSeriesProp = !!series;
-    const chartStyle = { overflow: 'visible', ...style };
+    const chartStyle = this.getChartStyle(style);
     // If you want to use functionality like Tooltips, pass the data component on the `series` prop
     const Series = hasSeriesProp ? series : children;
 

--- a/packages/react-jsx-highcharts/src/components/SeriesProvider/index.js
+++ b/packages/react-jsx-highcharts/src/components/SeriesProvider/index.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import memoizeOne from 'memoize-one';
 import DelayRender from '../DelayRender';
 import provideAxis from '../AxisProvider'
 import { Consumer } from '../SeriesContext';
@@ -8,6 +9,19 @@ import clean from '../../utils/removeProvidedProps';
 // This is a HOC function.
 // It takes a component...
 export default function provideSeries(Component) {
+
+  const createGetSeries = memoizeOne((series) => {
+    return () => ({
+      object: series,
+      id: series.userOptions && series.userOptions.id,
+      type: series.type,
+      update: clean(series.update.bind(series)),
+      remove: series.remove.bind(series),
+      setData: series.setData.bind(series),
+      setVisible: series.setVisible.bind(series)
+    });
+  });
+
   // ...and returns another component...
   const SeriesWrappedComponent = function(props) {
     // ... and renders the wrapped component with the context series
@@ -23,15 +37,7 @@ export default function provideSeries(Component) {
 
             if (!series) return null;
 
-            const getSeries = () => ({
-              object: series,
-              id: series.userOptions && series.userOptions.id,
-              type: series.type,
-              update: clean(series.update.bind(series)),
-              remove: series.remove.bind(series),
-              setData: series.setData.bind(series),
-              setVisible: series.setVisible.bind(series)
-            })
+            const getSeries = createGetSeries(series);
 
             return (
               <Component {...props} getSeries={getSeries} />

--- a/packages/react-jsx-highcharts/src/components/SeriesProvider/index.js
+++ b/packages/react-jsx-highcharts/src/components/SeriesProvider/index.js
@@ -10,17 +10,15 @@ import clean from '../../utils/removeProvidedProps';
 // It takes a component...
 export default function provideSeries(Component) {
 
-  const createGetSeries = memoizeOne((series) => {
-    return () => ({
-      object: series,
-      id: series.userOptions && series.userOptions.id,
-      type: series.type,
-      update: clean(series.update.bind(series)),
-      remove: series.remove.bind(series),
-      setData: series.setData.bind(series),
-      setVisible: series.setVisible.bind(series)
-    });
-  });
+  const createGetSeries = memoizeOne(series => () => ({
+    object: series,
+    id: series.userOptions && series.userOptions.id,
+    type: series.type,
+    update: clean(series.update.bind(series)),
+    remove: series.remove.bind(series),
+    setData: series.setData.bind(series),
+    setVisible: series.setVisible.bind(series)
+  }));
 
   // ...and returns another component...
   const SeriesWrappedComponent = function(props) {

--- a/packages/react-jsx-highmaps/package-lock.json
+++ b/packages/react-jsx-highmaps/package-lock.json
@@ -3319,6 +3319,12 @@
         }
       }
     },
+    "eslint-plugin-react-perf": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-perf/-/eslint-plugin-react-perf-3.2.0.tgz",
+      "integrity": "sha512-PnAsJPwCmoI4CBtF/Uk0v1dN4zvpWC3fO5BzG9O+q/c+6hXv9cFzgXht+CJzZaC61VuYBpjWdOs9ksBN6Py1iw==",
+      "dev": true
+    },
     "eslint-scope": {
       "version": "3.7.1",
       "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-3.7.1.tgz",

--- a/packages/react-jsx-highmaps/package-lock.json
+++ b/packages/react-jsx-highmaps/package-lock.json
@@ -6145,6 +6145,11 @@
         }
       }
     },
+    "memoize-one": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.1.1.tgz",
+      "integrity": "sha512-HKeeBpWvqiVJD57ZUAsJNm71eHTykffzcLZVYWiVfQeI1rJtuEaS7hQiEpWfVVk18donPwJEcFKIkCmPJNOhHA=="
+    },
     "memory-fs": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.4.1.tgz",

--- a/packages/react-jsx-highmaps/package.json
+++ b/packages/react-jsx-highmaps/package.json
@@ -62,6 +62,7 @@
     "eslint": "^5.16.0",
     "eslint-plugin-import": "^2.18.2",
     "eslint-plugin-react": "^7.14.2",
+    "eslint-plugin-react-perf": "^3.2.0",
     "highcharts": "^7.1.2",
     "jest": "^24.8.0",
     "jest-enzyme": "^7.0.2",

--- a/packages/react-jsx-highmaps/package.json
+++ b/packages/react-jsx-highmaps/package.json
@@ -44,6 +44,7 @@
   "dependencies": {
     "@babel/runtime": "^7.5.5",
     "lodash-es": "^4.17.13",
+    "memoize-one": "^5.1.1",
     "react-jsx-highcharts": "~3.6.0"
   },
   "devDependencies": {

--- a/packages/react-jsx-highmaps/src/components/HighchartsMapChart/HighchartsMapChart.js
+++ b/packages/react-jsx-highmaps/src/components/HighchartsMapChart/HighchartsMapChart.js
@@ -1,6 +1,11 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { BaseChart } from 'react-jsx-highcharts';
+import memoizeOne from 'memoize-one';
+
+const XAXIS = { id: 'xAxis' };
+const YAXIS = { id: 'yAxis' };
+const MAP_NAVIGATION = { enabled: false };
 
 class HighchartsMapChart extends Component {
   static propTypes = {
@@ -11,10 +16,15 @@ class HighchartsMapChart extends Component {
     callback: () => {}
   };
 
-  getGeoJSON = map => {
+  createGeoJSON = map => {
     if (!map) return;
-    return (typeof map === 'string') ? this.props.getHighcharts().maps[map] : map;
+    this.geojson = (typeof map === 'string') ? this.props.getHighcharts().maps[map] : map;
   }
+
+  getChartConfig = memoizeOne((chart, map) => {
+    this.createGeoJSON(map);
+    return { ...chart, map: this.geojson };
+  })
 
   callback = chart => {
     const geojson = this.geojson;
@@ -29,14 +39,14 @@ class HighchartsMapChart extends Component {
 
   render () {
     const { map, chart, ...rest } = this.props;
-    this.geojson = this.getGeoJSON(map);
+    const chartConfig = this.getChartConfig(chart, map);
 
     return (
       <BaseChart
-        chart={{ ...chart, map: this.geojson }}
-        mapNavigation={{ enabled: false }}
-        xAxis={{ id: 'xAxis' }}
-        yAxis={{ id: 'yAxis' }}
+        chart={chartConfig}
+        mapNavigation={MAP_NAVIGATION}
+        xAxis={XAXIS}
+        yAxis={YAXIS}
         {...rest}
         callback={this.callback}
         chartCreationFunc={this.props.getHighcharts().mapChart}

--- a/packages/react-jsx-highstock-datepickers/package.json
+++ b/packages/react-jsx-highstock-datepickers/package.json
@@ -52,6 +52,7 @@
     "eslint": "^5.16.0",
     "eslint-plugin-import": "^2.18.2",
     "eslint-plugin-react": "^7.13.0",
+    "eslint-plugin-react-perf": "^3.2.0",
     "mini-css-extract-plugin": "^0.8.0",
     "moment": "^2.24.0",
     "null-loader": "^3.0.0",

--- a/packages/react-jsx-highstock-datepickers/package.json
+++ b/packages/react-jsx-highstock-datepickers/package.json
@@ -26,6 +26,7 @@
   },
   "homepage": "https://github.com/whawker/react-jsx-highcharts#readme",
   "dependencies": {
+    "memoize-one": "^5.1.1",
     "react-day-picker": "^6.2.0"
   },
   "peerDependencies": {

--- a/packages/react-jsx-highstock-datepickers/src/index.js
+++ b/packages/react-jsx-highstock-datepickers/src/index.js
@@ -1,6 +1,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import moment from 'moment';
+import memoizeOne from 'memoize-one';
 import DayPickerInput from 'react-day-picker/DayPickerInput';
 import { provideAxis } from 'react-jsx-highstock';
 import 'react-day-picker/lib/style.css';
@@ -121,6 +122,10 @@ class DateRangePickers extends Component {
     });
   }
 
+  getDayPickerProps = memoizeOne((datePickerProps, localisationOpts) => {
+    return { ...datePickerProps, ...localisationOpts };
+  })
+
   render () {
     const axis = this.props.getAxis();
     if (!axis) return null;
@@ -138,6 +143,8 @@ class DateRangePickers extends Component {
     const fromDate = moment(min).format(dayFormat);
     const toDate = moment(max).format(dayFormat);
 
+    const dayPickerProps = this.getDayPickerProps(datePickerProps, localisationOpts);
+
     return (
       <div className={className}>
         <span className={`${className}__label ${className}__from-label`}>{fromLabel}: </span>
@@ -145,14 +152,14 @@ class DateRangePickers extends Component {
           value={fromDate}
           onDayChange={this.handleFromDateChange(onChangeFromDate)}
           format={dayFormat}
-          dayPickerProps={{ ...datePickerProps, ...localisationOpts }}
+          dayPickerProps={dayPickerProps}
         />
         <span className={`${className}__label ${className}__to-label`}>{toLabel}: </span>
         <DayPickerInput
           value={toDate}
           onDayChange={this.handleToDateChange(onChangeToDate)}
           format={dayFormat}
-          dayPickerProps={{ ...datePickerProps, ...localisationOpts }}
+          dayPickerProps={dayPickerProps}
         />
       </div>
     );

--- a/packages/react-jsx-highstock/package-lock.json
+++ b/packages/react-jsx-highstock/package-lock.json
@@ -3319,6 +3319,12 @@
         }
       }
     },
+    "eslint-plugin-react-perf": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-perf/-/eslint-plugin-react-perf-3.2.0.tgz",
+      "integrity": "sha512-PnAsJPwCmoI4CBtF/Uk0v1dN4zvpWC3fO5BzG9O+q/c+6hXv9cFzgXht+CJzZaC61VuYBpjWdOs9ksBN6Py1iw==",
+      "dev": true
+    },
     "eslint-scope": {
       "version": "3.7.1",
       "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-3.7.1.tgz",

--- a/packages/react-jsx-highstock/package.json
+++ b/packages/react-jsx-highstock/package.json
@@ -78,6 +78,7 @@
     "eslint": "^5.16.0",
     "eslint-plugin-import": "^2.18.2",
     "eslint-plugin-react": "^7.14.2",
+    "eslint-plugin-react-perf": "^3.2.0",
     "highcharts": "^7.1.2",
     "jest": "^24.8.0",
     "jest-enzyme": "^7.0.2",


### PR DESCRIPTION
I added eslint-plugin-react-perf to detect performance problems in eslint.

It currently errors out, but it could prevent problems like #216.

@whawker do you think these rules should be turned into warnings and merge this to master? After fixing these the rules should probably be turned to errors.