### PR TITLE
Add back missing @babel/runtime

### DIFF
--- a/packages/react-jsx-highcharts/package.json
+++ b/packages/react-jsx-highcharts/package.json
@@ -88,6 +88,7 @@
     "webpack-cli": "^3.3.6"
   },
   "dependencies": {
+    "@babel/runtime": "^7.5.5",
     "immutable-is": "^3.7.6",
     "is-immutable": "^1.0.1",
     "lodash-es": "^4.17.13",


### PR DESCRIPTION
Babel runtime is missing from dependencies. I guess it was removed accidentally by https://github.com/whawker/react-jsx-highcharts/commit/fcb445ff0577341c2d76206682c054d642f5a6bd

This PR adds it back.

Probably needs a release, otherwise some people might have problems using the library.