### PR TITLE
Allow Chart event handlers to be updated

### DIFF
--- a/packages/react-jsx-highcharts/src/components/Chart/Chart.js
+++ b/packages/react-jsx-highcharts/src/components/Chart/Chart.js
@@ -1,16 +1,12 @@
 import { useEffect, useRef, memo } from 'react';
 import PropTypes from 'prop-types';
-import {
-  addEventHandlersManually,
-  getNonEventHandlerProps
-} from '../../utils/events';
+import { getNonEventHandlerProps } from '../../utils/events';
 import useModifiedProps from '../UseModifiedProps';
 import useChart from '../UseChart';
-import useHighcharts from '../UseHighcharts';
+import useManualEventHandlers from '../UseManualEventHandlers';
 
 const Chart = memo(({ type = 'line', ...restProps }) => {
   const chart = useChart();
-  const Highcharts = useHighcharts();
   const mounted = useRef(false);
 
   const modifiedProps = useModifiedProps(restProps);
@@ -21,9 +17,9 @@ const Chart = memo(({ type = 'line', ...restProps }) => {
       if (width || height) {
         chart.setSize(restProps.width, restProps.height);
       }
-      if (Object.getOwnPropertyNames(restModified).length > 0) {
+      const notEventProps = getNonEventHandlerProps(restModified);
+      if (Object.getOwnPropertyNames(notEventProps).length > 0) {
         updateChart(restModified, chart, chart.needsRedraw);
-        addEventHandlersManually(Highcharts, chart.object, restModified);
       }
     }
   });
@@ -35,9 +31,10 @@ const Chart = memo(({ type = 'line', ...restProps }) => {
 
     chart.setSize(width, height);
     updateChart(notEventProps, chart);
-    addEventHandlersManually(Highcharts, chart.object, rest);
     mounted.current = true;
   }, []);
+
+  useManualEventHandlers(restProps, chart.object);
 
   return null;
 });

--- a/packages/react-jsx-highcharts/src/components/Chart/Chart.js
+++ b/packages/react-jsx-highcharts/src/components/Chart/Chart.js
@@ -23,6 +23,7 @@ const Chart = memo(({ type = 'line', ...restProps }) => {
       }
       if (Object.getOwnPropertyNames(restModified).length > 0) {
         updateChart(restModified, chart, chart.needsRedraw);
+        addEventHandlersManually(Highcharts, chart.object, restModified);
       }
     }
   });

--- a/packages/react-jsx-highcharts/src/components/UseManualEventHandlers/index.js
+++ b/packages/react-jsx-highcharts/src/components/UseManualEventHandlers/index.js
@@ -14,15 +14,17 @@ const useManualEventHandlers = function(props, target) {
   );
 
   if (modifiedEvenHandlers !== false) {
-    Object.entries(modifiedEvenHandlers).forEach(([eventName, newHandler]) => {
+    Object.keys(modifiedEvenHandlers).forEach(eventName => {
       if (previousEventHandlers) {
         const oldHandler = previousEventHandlers[eventName];
         if (oldHandler) {
           Highcharts.removeEvent(target, eventName, oldHandler);
         }
       }
-
-      Highcharts.addEvent(target, eventName, newHandler);
+      const newHandler = modifiedEvenHandlers[eventName];
+      if (newHandler) {
+        Highcharts.addEvent(target, eventName, newHandler);
+      }
     });
   }
 };

--- a/packages/react-jsx-highcharts/src/components/UseManualEventHandlers/index.js
+++ b/packages/react-jsx-highcharts/src/components/UseManualEventHandlers/index.js
@@ -1,0 +1,30 @@
+import useHighcharts from '../UseHighcharts';
+import usePrevious from '../UsePrevious';
+import { getEventsConfig } from '../../utils/events';
+import getModifiedProps from '../../utils/getModifiedProps';
+
+const useManualEventHandlers = function(props, target) {
+  const Highcharts = useHighcharts();
+  const eventHandlers = getEventsConfig(props);
+  const previousEventHandlers = usePrevious(eventHandlers);
+
+  const modifiedEvenHandlers = getModifiedProps(
+    previousEventHandlers,
+    eventHandlers
+  );
+
+  if (modifiedEvenHandlers !== false) {
+    Object.entries(modifiedEvenHandlers).forEach(([eventName, newHandler]) => {
+      if (previousEventHandlers) {
+        const oldHandler = previousEventHandlers[eventName];
+        if (oldHandler) {
+          Highcharts.removeEvent(target, eventName, oldHandler);
+        }
+      }
+
+      Highcharts.addEvent(target, eventName, newHandler);
+    });
+  }
+};
+
+export default useManualEventHandlers;

--- a/packages/react-jsx-highcharts/src/utils/events.js
+++ b/packages/react-jsx-highcharts/src/utils/events.js
@@ -29,12 +29,5 @@ export const addEventHandlersManually = (Highcharts, context, props) => {
   });
 };
 
-export const addEventHandlers = (updateFn, props, redraw = true) => {
-  const events = getEventsConfig(props);
-  updateFn({ events }, redraw);
-};
-
 const _isEventKey = (key, value) =>
   key.indexOf('on') === 0 && key.length > 2 && typeof value === 'function';
-
-export default addEventHandlers;

--- a/packages/react-jsx-highcharts/src/utils/events.js
+++ b/packages/react-jsx-highcharts/src/utils/events.js
@@ -24,6 +24,7 @@ export const addEventHandlersManually = (Highcharts, context, props) => {
   const eventProps = getEventsConfig(props);
 
   Object.keys(eventProps).forEach(eventName => {
+    Highcharts.removeEvent(context, eventName);
     Highcharts.addEvent(context, eventName, eventProps[eventName]);
   });
 };

--- a/packages/react-jsx-highcharts/test/components/Chart/Chart.spec.js
+++ b/packages/react-jsx-highcharts/test/components/Chart/Chart.spec.js
@@ -115,21 +115,23 @@ describe('<Chart />', () => {
     it('should update changed eventhandlers', () => {
       testContext.chartStubs.object = {};
       const onSelection = jest.fn();
+      const onRedraw = jest.fn();
       const wrapper = mount(
-        <ProvidedChart onSelection={onSelection} onRedraw={jest.fn()} />
+        <ProvidedChart onSelection={onSelection} onRedraw={onRedraw} />
       );
       Highcharts.addEvent.mockClear();
       Highcharts.removeEvent.mockClear();
-      const onRedraw = jest.fn();
-      wrapper.setProps({ onRedraw });
+      const newOnRedraw = jest.fn();
+      wrapper.setProps({ onRedraw: newOnRedraw });
       expect(Highcharts.removeEvent).toHaveBeenCalledWith(
         testContext.chartStubs.object,
-        'redraw'
+        'redraw',
+        onRedraw
       );
       expect(Highcharts.addEvent).toHaveBeenCalledWith(
         testContext.chartStubs.object,
         'redraw',
-        onRedraw
+        newOnRedraw
       );
       expect(Highcharts.addEvent).not.toHaveBeenCalledWith(
         testContext.chartStubs.object,

--- a/packages/react-jsx-highcharts/test/components/Chart/Chart.spec.js
+++ b/packages/react-jsx-highcharts/test/components/Chart/Chart.spec.js
@@ -112,6 +112,32 @@ describe('<Chart />', () => {
       expect(testContext.needsRedraw).toHaveBeenCalledTimes(2);
     });
 
+    it('should update changed eventhandlers', () => {
+      testContext.chartStubs.object = {};
+      const onSelection = jest.fn();
+      const wrapper = mount(
+        <ProvidedChart onSelection={onSelection} onRedraw={jest.fn()} />
+      );
+      Highcharts.addEvent.mockClear();
+      Highcharts.removeEvent.mockClear();
+      const onRedraw = jest.fn();
+      wrapper.setProps({ onRedraw });
+      expect(Highcharts.removeEvent).toHaveBeenCalledWith(
+        testContext.chartStubs.object,
+        'redraw'
+      );
+      expect(Highcharts.addEvent).toHaveBeenCalledWith(
+        testContext.chartStubs.object,
+        'redraw',
+        onRedraw
+      );
+      expect(Highcharts.addEvent).not.toHaveBeenCalledWith(
+        testContext.chartStubs.object,
+        'selection',
+        onSelection
+      );
+    });
+
     it('updates the size of the chart if the width or height change', () => {
       const wrapper = mount(<ProvidedChart width={400} height="75%" />);
 

--- a/packages/react-jsx-highcharts/test/test-utils.js
+++ b/packages/react-jsx-highcharts/test/test-utils.js
@@ -4,7 +4,7 @@ const noop = () => {};
 export const Highcharts = {
   chart: jest.fn(),
   addEvent: jest.fn(),
-  removeEvent: noop,
+  removeEvent: jest.fn(),
   Tooltip: jest.fn().mockImplementation(() => ({ update: jest.fn() }))
 };
 

--- a/packages/react-jsx-highcharts/test/utils/events.spec.js
+++ b/packages/react-jsx-highcharts/test/utils/events.spec.js
@@ -4,6 +4,7 @@ import { Highcharts } from '../test-utils';
 describe('utils/events', () => {
   beforeEach(() => {
     Highcharts.addEvent.mockClear();
+    Highcharts.removeEvent.mockClear();
   });
 
   describe('getEventHandlerProps', () => {
@@ -122,16 +123,27 @@ describe('utils/events', () => {
       const context = {};
 
       addEventHandlersManually(Highcharts, context, config);
-
+      expect(Highcharts.removeEvent).toHaveBeenCalledWith(
+        context,
+        'eventHandler'
+      );
       expect(Highcharts.addEvent).toHaveBeenCalledWith(
         context,
         'eventHandler',
         onEventHandler
       );
+      expect(Highcharts.removeEvent).toHaveBeenCalledWith(
+        context,
+        'otherEventHandler'
+      );
       expect(Highcharts.addEvent).toHaveBeenCalledWith(
         context,
         'otherEventHandler',
         onOtherEventHandler
+      );
+      expect(Highcharts.removeEvent).not.toHaveBeenCalledWith(
+        context,
+        'onNotAFunction'
       );
       expect(Highcharts.addEvent).not.toHaveBeenCalledWith(
         context,

--- a/packages/react-jsx-highcharts/test/utils/events.spec.js
+++ b/packages/react-jsx-highcharts/test/utils/events.spec.js
@@ -75,36 +75,6 @@ describe('utils/events', () => {
     });
   });
 
-  describe('addEventHandlers', () => {
-    const { addEventHandlers } = events;
-
-    it('should call the provided function with an events property with things that look like event handlers', () => {
-      const spy = jest.fn();
-      const onEventHandler = jest.fn();
-      const onOtherEventHandler = jest.fn();
-
-      const config = {
-        enabled: true,
-        onEventHandler,
-        onOtherEventHandler,
-        onNotAFunction: 'trip',
-        something: 'stringy',
-        count: 14
-      };
-      addEventHandlers(spy, config);
-
-      expect(spy).toHaveBeenCalledWith(
-        {
-          events: {
-            eventHandler: onEventHandler,
-            otherEventHandler: onOtherEventHandler
-          }
-        },
-        true
-      );
-    });
-  });
-
   describe('addEventHandlersManually', () => {
     const { addEventHandlersManually } = events;
 


### PR DESCRIPTION
This allows chart event handlers to be updated.

When parent component is hooks based, the passed in event handler might need to change:
```javascript
const onSelection = useCallback(() => {
  // do something with prop that changes
}, [props.somechangingprop]);
```