### PR TITLE
Fix navigator

### DIFF
--- a/packages/react-jsx-highcharts/src/components/PlotBandLine/UsePlotBandLineLifecycle.js
+++ b/packages/react-jsx-highcharts/src/components/PlotBandLine/UsePlotBandLineLifecycle.js
@@ -3,6 +3,7 @@ import uuid from 'uuid/v4';
 import { attempt } from 'lodash-es';
 import useModifiedProps from '../UseModifiedProps';
 import useAxis from '../UseAxis';
+import usePrevious from '../UsePrevious';
 
 export default function usePlotBandLineLifecycle(props, plotType) {
   const { id = uuid, axisId, children, ...rest } = props;
@@ -11,10 +12,11 @@ export default function usePlotBandLineLifecycle(props, plotType) {
   const idRef = useRef();
   const [plotbandline, setPlotbandline] = useState(null);
   const modifiedProps = useModifiedProps(rest);
+  const prevAxis = usePrevious(axis);
 
   useEffect(() => {
     if (!axis) return;
-    if (!plotbandline || modifiedProps !== false) {
+    if (!plotbandline || modifiedProps !== false || prevAxis !== axis) {
       if (!plotbandline) {
         idRef.current = typeof id === 'function' ? id() : id;
       }

--- a/packages/react-jsx-highstock/jest.config.js
+++ b/packages/react-jsx-highstock/jest.config.js
@@ -168,7 +168,7 @@ module.exports = {
   //   "/node_modules/"
   // ],
   "transformIgnorePatterns": [
-    "node_modules/(?!(lodash-es)/)"
+    "node_modules/(?!(lodash-es|react-jsx-highcharts)/)"
   ]
   // An array of regexp pattern strings that are matched against all modules before the module loader will automatically return a mock for them
   // unmockedModulePathPatterns: undefined,

--- a/packages/react-jsx-highstock/src/components/Navigator/Navigator.js
+++ b/packages/react-jsx-highstock/src/components/Navigator/Navigator.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useRef, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { attempt } from 'lodash-es';
 import {
@@ -8,39 +8,35 @@ import {
 } from 'react-jsx-highcharts';
 import NavigatorXAxis from './NavigatorXAxis';
 
-const Navigator = ({ enabled = true, ...restProps }) => {
+const Navigator = ({ enabled = true, children, ...restProps }) => {
   const props = { enabled, ...restProps };
-  const [rendered, setRendered] = useState(false);
+  const renderedRef = useRef(false);
   const chart = useChart();
   const Highcharts = useHighcharts();
+  const modifiedProps = useModifiedProps(props);
 
   useEffect(() => {
-    const { children, ...rest } = props;
+    return () => {
+      attempt(updateNavigator, { enabled: false }, chart);
+    };
+  }, []);
+
+  if (!renderedRef.current) {
     // Workaround from http://jsfiddle.net/x40me94t/2/
     const chartObj = chart.object;
     chartObj.options.navigator.enabled = true;
     // Initialise Navigator https://github.com/highcharts/highcharts/blob/dd730ab/js/parts/Navigator.js#L1837-L1844
     Highcharts.fireEvent(chartObj, 'beforeRender');
 
-    updateNavigator(rest, chart);
-
-    setRendered(true);
-
-    return () => {
-      attempt(updateNavigator, { enabled: false }, chart);
-    };
-  }, []);
-
-  const modifiedProps = useModifiedProps(props);
-
-  useEffect(() => {
+    updateNavigator(props, chart);
+    renderedRef.current = true;
+  } else {
     if (modifiedProps !== false) {
       updateNavigator(modifiedProps, chart);
     }
-  });
+  }
 
-  const { children } = props;
-  if (!children || !rendered) return null;
+  if (!children) return null;
 
   return <NavigatorXAxis>{children}</NavigatorXAxis>;
 };

--- a/packages/react-jsx-highstock/src/components/Navigator/NavigatorXAxis.js
+++ b/packages/react-jsx-highstock/src/components/Navigator/NavigatorXAxis.js
@@ -2,7 +2,7 @@ import React from 'react';
 import NavigatorAxis from './NavigatorAxis';
 
 const NavigatorXAxis = props => (
-  <NavigatorAxis {...props} axisId="navigator-x-axis" />
+  <NavigatorAxis {...props} axisId="navigator-x-axis" axisType="xAxis" />
 );
 
 export default NavigatorXAxis;

--- a/packages/react-jsx-highstock/src/components/Navigator/NavigatorYAxis.js
+++ b/packages/react-jsx-highstock/src/components/Navigator/NavigatorYAxis.js
@@ -2,7 +2,7 @@ import React from 'react';
 import NavigatorAxis from './NavigatorAxis';
 
 const NavigatorYAxis = props => (
-  <NavigatorAxis {...props} axisId="navigator-y-axis" />
+  <NavigatorAxis {...props} axisId="navigator-y-axis" axisType="yAxis" />
 );
 
 export default NavigatorYAxis;

--- a/packages/react-jsx-highstock/test/components/Navigator/Navigator.spec.js
+++ b/packages/react-jsx-highstock/test/components/Navigator/Navigator.spec.js
@@ -63,6 +63,7 @@ describe('<Navigator />', () => {
   describe('update', () => {
     it('should use the update method when props change', () => {
       const wrapper = mount(<Navigator />);
+      testContext.chartStubs.update.mockClear();
       wrapper.setProps({ maskInside: false });
       expect(testContext.chartStubs.update).toHaveBeenCalledWith(
         {

--- a/packages/react-jsx-highstock/test/components/Navigator/NavigatorXAxis.integration.spec.js
+++ b/packages/react-jsx-highstock/test/components/Navigator/NavigatorXAxis.integration.spec.js
@@ -1,0 +1,101 @@
+import React from 'react';
+import Highstock from 'highcharts/highstock';
+import {
+  Chart,
+  Debug,
+  XAxis,
+  YAxis,
+  LineSeries,
+  withHighcharts
+} from 'react-jsx-highcharts';
+import { HighchartsStockChart, Navigator } from '../../../src';
+
+describe('<NavigatorXAxis /> integration', () => {
+  describe('when mounted', () => {
+    it('passes additional props to navigators xAxis', () => {
+      const data = [1, 2, 3, 4, 5];
+      const labels = { x: 0, y: 12 };
+      const Component = props => {
+        return (
+          <HighchartsStockChart>
+            <Debug />
+            <Chart />
+            <XAxis />
+            <YAxis>
+              <LineSeries data={data} />
+            </YAxis>
+            <Navigator>
+              <Navigator.XAxis labels={labels} />
+            </Navigator>
+          </HighchartsStockChart>
+        );
+      };
+      const WithComponent = withHighcharts(Component, Highstock);
+      mount(<WithComponent />);
+      const chart = window.chart;
+      expect(chart.options.navigator.xAxis.labels).toEqual(
+        expect.objectContaining(labels)
+      );
+    });
+  });
+
+  describe('when updated', () => {
+    it('changes the navigator labels', () => {
+      const data = [1, 2, 3, 4, 5];
+      const labels = { x: 0, y: 12 };
+      const Component = props => {
+        return (
+          <HighchartsStockChart>
+            <Debug />
+            <Chart />
+            <XAxis />
+            <YAxis>
+              <LineSeries data={data} />
+            </YAxis>
+            <Navigator>
+              <Navigator.XAxis {...props} />
+            </Navigator>
+          </HighchartsStockChart>
+        );
+      };
+
+      const WithComponent = withHighcharts(Component, Highstock);
+      const wrapper = mount(<WithComponent />);
+      wrapper.setProps({ labels });
+      const chart = window.chart;
+      expect(chart.options.navigator.xAxis.labels).toEqual(
+        expect.objectContaining(labels)
+      );
+    });
+  });
+
+  describe('when parent navigator updated', () => {
+    it('keeps the axis labels', () => {
+      const data = [1, 2, 3, 4, 5];
+      const labels = { x: 0, y: 12 };
+      const Component = props => {
+        return (
+          <HighchartsStockChart>
+            <Debug />
+            <Chart />
+            <XAxis />
+            <YAxis>
+              <LineSeries data={data} />
+            </YAxis>
+            <Navigator {...props}>
+              <Navigator.XAxis labels={labels} />
+            </Navigator>
+          </HighchartsStockChart>
+        );
+      };
+
+      const WithComponent = withHighcharts(Component, Highstock);
+      const wrapper = mount(<WithComponent />);
+      wrapper.setProps({ height: 100 });
+      const chart = window.chart;
+      expect(chart.options.navigator.xAxis.labels).toEqual(
+        expect.objectContaining(labels)
+      );
+    });
+  });
+});


### PR DESCRIPTION
This fixes navigator crash when updated (https://github.com/whawker/react-jsx-highcharts/issues/228#issuecomment-551308361).

The root cause was that navigator re-creates it's axes when navigator is updated.

There were several problems:
1. 3e65a8d creates axis earlier, so that navigator can access the parent series axis
2. b8e74fd allows provided axis to change, so that plotbands can react to axis changes
3. cf538e7 forces plotbands to re-render when axis was changed
4. e1d3ff1 fixes the navigator itself

Related issue on highcharts repository: https://github.com/highcharts/highcharts/issues/12406

Probably more axis consumers, like Annotations and maybe Series need updating, but maybe we should test this in another alpha first?