### PR TITLE
Add a isDataEqual prop, for custom Series data comparison

### DIFF
--- a/packages/react-jsx-highcharts/src/components/Series/Series.js
+++ b/packages/react-jsx-highcharts/src/components/Series/Series.js
@@ -19,6 +19,7 @@ const Series = memo(
   ({
     id = uuid,
     data = EMPTY_ARRAY,
+    isDataEqual = Object.is,
     type = 'line',
     visible = true,
     children = null,
@@ -79,7 +80,7 @@ const Series = memo(
 
       let doRedraw = false;
       // Using setData is more performant than update
-      if (Object.is(data, prevProps.data) === false) {
+      if (isDataEqual(data, prevProps.data) === false) {
         series.setData(data, false);
         doRedraw = true;
       }
@@ -114,6 +115,7 @@ Series.propTypes = {
   id: PropTypes.oneOfType([PropTypes.string, PropTypes.func]),
   type: PropTypes.string,
   data: PropTypes.any,
+  isDataEqual: PropTypes.func,
   visible: PropTypes.bool,
   children: PropTypes.node,
   axisId: PropTypes.string,

--- a/packages/react-jsx-highcharts/test/components/Series/Series.spec.js
+++ b/packages/react-jsx-highcharts/test/components/Series/Series.spec.js
@@ -205,6 +205,29 @@ describe('<Series />', () => {
       expect(testContext.needsRedraw).toHaveBeenCalled();
     });
 
+    it('should use the isDataEqual prop to compare data', () => {
+      const isDataEqual = jest.fn(() => false);
+      const wrapper = mount(<ProvidedSeries id="mySeries" data={[1, 2, 3]} isDataEqual={isDataEqual} />);
+      wrapper.setProps({ data: [4, 5, 6] });
+      expect(isDataEqual).toHaveBeenCalledWith([4, 5, 6], [1, 2, 3]);
+    });
+
+    it('should NOT setData if isDataEqual returns true', () => {
+      const isDataEqual = jest.fn(() => true);
+      const wrapper = mount(<ProvidedSeries id="mySeries" data={[1, 2, 3]} isDataEqual={isDataEqual} />);
+      testContext.seriesStubs.setData.mockClear();
+      wrapper.setProps({ data: [4, 5, 6] });
+      expect(testContext.seriesStubs.setData).not.toHaveBeenCalled();
+    });
+
+    it('should setData if isDataEqual returns false', () => {
+      const isDataEqual = jest.fn(() => false);
+      const wrapper = mount(<ProvidedSeries id="mySeries" data={[1, 2, 3]} isDataEqual={isDataEqual} />);
+      testContext.seriesStubs.setData.mockClear();
+      wrapper.setProps({ data: [4, 5, 6] });
+      expect(testContext.seriesStubs.setData).toHaveBeenCalled();
+    });
+
     it('should use the setVisible method on the correct series when the visibility changes', () => {
       const wrapper = mount(<ProvidedSeries id="mySeries" visible />);
       testContext.seriesStubs.update.mockReset();

--- a/packages/react-jsx-highcharts/test/components/Series/Series.spec.js
+++ b/packages/react-jsx-highcharts/test/components/Series/Series.spec.js
@@ -166,10 +166,16 @@ describe('<Series />', () => {
   });
 
   describe('update', () => {
+    const resetMocks = () => {
+      testContext.seriesStubs.update.mockReset();
+      testContext.seriesStubs.setData.mockReset();
+      testContext.seriesStubs.setVisible.mockReset();
+      testContext.needsRedraw.mockReset();
+    };
+
     it('should use the setData method on the correct series when the data changes', () => {
       const wrapper = mount(<ProvidedSeries id="mySeries" data={[]} />);
-      testContext.seriesStubs.update.mockReset();
-      testContext.needsRedraw.mockClear();
+      resetMocks();
       wrapper.setProps({ data: [1, 2, 3] });
       expect(testContext.seriesStubs.setData).toHaveBeenCalledWith(
         [1, 2, 3],
@@ -184,9 +190,7 @@ describe('<Series />', () => {
     it("should NOT use the setData method if the data reference hasn't changed", () => {
       const data = [1, 2, 3];
       const wrapper = mount(<ProvidedSeries id="mySeries" data={data} />);
-      testContext.seriesStubs.update.mockClear();
-      testContext.needsRedraw.mockClear();
-      testContext.seriesStubs.setData.mockClear();
+      resetMocks();
       wrapper.setProps({ data });
       expect(testContext.seriesStubs.setData).not.toHaveBeenCalled();
       expect(testContext.seriesStubs.update).not.toHaveBeenCalled();
@@ -196,8 +200,7 @@ describe('<Series />', () => {
 
     it('should use the setData method if the data reference has changed', () => {
       const wrapper = mount(<ProvidedSeries id="mySeries" data={[1, 2, 3]} />);
-      testContext.seriesStubs.update.mockClear();
-      testContext.needsRedraw.mockClear();
+      resetMocks();
       wrapper.setProps({ data: [1, 2, 3] });
       expect(testContext.seriesStubs.setData).toHaveBeenCalled();
       expect(testContext.seriesStubs.update).not.toHaveBeenCalled();
@@ -215,7 +218,7 @@ describe('<Series />', () => {
     it('should NOT setData if isDataEqual returns true', () => {
       const isDataEqual = jest.fn(() => true);
       const wrapper = mount(<ProvidedSeries id="mySeries" data={[1, 2, 3]} isDataEqual={isDataEqual} />);
-      testContext.seriesStubs.setData.mockClear();
+      resetMocks();
       wrapper.setProps({ data: [4, 5, 6] });
       expect(testContext.seriesStubs.setData).not.toHaveBeenCalled();
     });
@@ -223,15 +226,14 @@ describe('<Series />', () => {
     it('should setData if isDataEqual returns false', () => {
       const isDataEqual = jest.fn(() => false);
       const wrapper = mount(<ProvidedSeries id="mySeries" data={[1, 2, 3]} isDataEqual={isDataEqual} />);
-      testContext.seriesStubs.setData.mockClear();
+      resetMocks();
       wrapper.setProps({ data: [4, 5, 6] });
       expect(testContext.seriesStubs.setData).toHaveBeenCalled();
     });
 
     it('should use the setVisible method on the correct series when the visibility changes', () => {
       const wrapper = mount(<ProvidedSeries id="mySeries" visible />);
-      testContext.seriesStubs.update.mockReset();
-      testContext.needsRedraw.mockClear();
+      resetMocks();
       wrapper.setProps({ visible: false });
       expect(testContext.seriesStubs.setVisible).toHaveBeenCalledWith(
         false,
@@ -244,7 +246,7 @@ describe('<Series />', () => {
 
     it('should use the update method on correct series if arbritary props change', () => {
       const wrapper = mount(<ProvidedSeries id="mySeries" visible />);
-      testContext.needsRedraw.mockClear();
+      resetMocks();
       wrapper.setProps({ newPropName: 'newPropValue' });
       expect(testContext.seriesStubs.update).toHaveBeenCalledWith(
         {
@@ -261,7 +263,7 @@ describe('<Series />', () => {
       const wrapper = mount(
         <ProvidedSeries id="mySeries" data={[]} visible={false} />
       );
-      testContext.needsRedraw.mockClear();
+      resetMocks();
       wrapper.setProps({ opposite: true, data: [4, 5, 6], visible: true });
       expect(testContext.seriesStubs.setData).toHaveBeenCalledWith(
         [4, 5, 6],


### PR DESCRIPTION
I felt uneasy about changing the behaviour of Lodash's `isEqual` to `Object.is`, I fear it may create confusion when upgrading versions.

Therefore, I have added an `isDataEqual` prop to `Series`, of the form

```js
(data, prevData) => boolean
``` 

If the returned boolean is 
 * `true` - data hasn't changed, then `setData` *isn't* called
 * `false`- data *has* changed, so `setData` is called

This allows users to override the default `Object.is` behaviour, and re-inject Lodash's `isEqual` if they choose.