### PR TITLE
Drop support for highchart < 8

### DIFF
--- a/packages/react-jsx-highcharts/package.json
+++ b/packages/react-jsx-highcharts/package.json
@@ -97,7 +97,7 @@
     "uuid": "^3.3.3"
   },
   "peerDependencies": {
-    "highcharts": "^7.2.0 || ^8.0.0",
+    "highcharts": "^8.0.0",
     "react": "^16.8.6",
     "react-dom": "^16.8.6",
     "prop-types": "^15.0.0"

--- a/packages/react-jsx-highmaps/package.json
+++ b/packages/react-jsx-highmaps/package.json
@@ -81,7 +81,7 @@
     "webpack-cli": "^3.3.10"
   },
   "peerDependencies": {
-    "highcharts": "^7.2.0 || ^8.0.0",
+    "highcharts": "^8.0.0",
     "prop-types": "^15.0.0",
     "react": "^16.8.6",
     "react-dom": "^16.8.6"

--- a/packages/react-jsx-highstock/package.json
+++ b/packages/react-jsx-highstock/package.json
@@ -97,7 +97,7 @@
     "webpack-cli": "^3.3.10"
   },
   "peerDependencies": {
-    "highcharts": "^7.2.0 || ^8.0.0",
+    "highcharts": "^8.0.0",
     "prop-types": "^15.0.0",
     "react": "^16.8.6",
     "react-dom": "^16.8.6"


### PR DESCRIPTION
Highcharts 8 doesn't seem to have any breaking changes, so this isn't technically needed now.

On the other hand Highcharts 7 doesn't get updates anymore, so it would be easier to drop support now if anything in Highchart 8 helps us to make simpler code.

What do you think?