### PR TITLE
Fix importing in SSR app

### DIFF
--- a/packages/react-jsx-highcharts/src/utils/debounce-raf.js
+++ b/packages/react-jsx-highcharts/src/utils/debounce-raf.js
@@ -13,10 +13,11 @@ WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
 ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
 OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 */
-const cancelAnimationFrame = window.cancelAnimationFrame;
-const requestAnimationFrame = window.requestAnimationFrame;
 
 export default function(fn) {
+  const cancelAnimationFrame = window.cancelAnimationFrame;
+  const requestAnimationFrame = window.requestAnimationFrame;
+
   var queued;
   return function(...args) {
     if (queued) cancelAnimationFrame(queued);


### PR DESCRIPTION
This should fix the issue reported in https://github.com/whawker/react-jsx-highcharts-examples/issues/2

Importing debounce-raf caused exception when window was not available.