### PR TITLE
Set babel runtime version to make smaller bundle

### DIFF
--- a/packages/react-jsx-highcharts/babel.config.js
+++ b/packages/react-jsx-highcharts/babel.config.js
@@ -1,11 +1,14 @@
 /* eslint-env node */
 const ENV = process.env.BABEL_ENV || process.env.NODE_ENV || 'development';
+const pkg = require('./package.json');
+const runtimeVersion = pkg.dependencies['@babel/runtime'];
+
 let config = {
   plugins: [
     '@babel/plugin-proposal-class-properties',
     [
       '@babel/transform-runtime',
-      { useESModules: ENV === 'test' ? false : true }
+      { version: runtimeVersion, useESModules: ENV === 'test' ? false : true }
     ]
   ],
   presets: [

--- a/packages/react-jsx-highmaps/babel.config.js
+++ b/packages/react-jsx-highmaps/babel.config.js
@@ -1,11 +1,14 @@
 /* eslint-env node */
 const ENV = process.env.BABEL_ENV || process.env.NODE_ENV || 'development';
+const pkg = require('./package.json');
+const runtimeVersion = pkg.dependencies['@babel/runtime'];
+
 let config = {
   plugins: [
     '@babel/plugin-proposal-class-properties',
     [
       '@babel/transform-runtime',
-      { useESModules: ENV === 'test' ? false : true }
+      { version: runtimeVersion, useESModules: ENV === 'test' ? false : true }
     ]
   ],
   presets: [

--- a/packages/react-jsx-highstock/babel.config.js
+++ b/packages/react-jsx-highstock/babel.config.js
@@ -1,11 +1,14 @@
 /* eslint-env node */
 const ENV = process.env.BABEL_ENV || process.env.NODE_ENV || 'development';
+const pkg = require('./package.json');
+const runtimeVersion = pkg.dependencies['@babel/runtime'];
+
 let config = {
   plugins: [
     '@babel/plugin-proposal-class-properties',
     [
       '@babel/transform-runtime',
-      { useESModules: ENV === 'test' ? false : true }
+      { version: runtimeVersion, useESModules: ENV === 'test' ? false : true }
     ]
   ],
   presets: [


### PR DESCRIPTION
This sets used runtime version for @babel/transform-runtime.
https://babeljs.io/docs/en/babel-plugin-transform-runtime#version

It results in a much smaller bundle, as transform can depend on newer features be present on runtime.

react-jsx-highcharts bundle: 36586 - 29043 = 7543 bytes saved.
