### PR TITLE
Upgrade to prettier v2

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,4 +1,6 @@
 {
   "singleQuote": true,
-  "tabWidth": 2
+  "tabWidth": 2,
+  "trailingComma": "none",
+  "arrowParens": "avoid"
 }

--- a/.prettierrc
+++ b/.prettierrc
@@ -2,5 +2,6 @@
   "singleQuote": true,
   "tabWidth": 2,
   "trailingComma": "none",
-  "arrowParens": "avoid"
+  "arrowParens": "avoid",
+  "endOfLine": "auto"
 }

--- a/packages/react-jsx-highcharts/package-lock.json
+++ b/packages/react-jsx-highcharts/package-lock.json
@@ -9646,9 +9646,9 @@
       "dev": true
     },
     "prettier": {
-      "version": "1.19.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.19.1.tgz",
-      "integrity": "sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.0.5.tgz",
+      "integrity": "sha512-7PtVymN48hGcO4fGjybyBSIWDsLU4H4XlvOHfq91pz9kkGlonzwTfYkaIEwiRg/dAJF9YlbsduBAgtYLi+8cFg==",
       "dev": true
     },
     "prettier-linter-helpers": {

--- a/packages/react-jsx-highcharts/package.json
+++ b/packages/react-jsx-highcharts/package.json
@@ -82,7 +82,7 @@
     "jest": "^25.4.0",
     "jest-enzyme": "^7.1.2",
     "lodash-webpack-plugin": "^0.11.5",
-    "prettier": "^1.19.1",
+    "prettier": "^2.0.5",
     "prop-types": "^15.7.2",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",

--- a/packages/react-jsx-highcharts/src/components/UseManualEventHandlers/index.js
+++ b/packages/react-jsx-highcharts/src/components/UseManualEventHandlers/index.js
@@ -3,7 +3,7 @@ import usePrevious from '../UsePrevious';
 import { getEventsConfig } from '../../utils/events';
 import getModifiedProps from '../../utils/getModifiedProps';
 
-const useManualEventHandlers = function(props, target) {
+const useManualEventHandlers = function (props, target) {
   const Highcharts = useHighcharts();
   const eventHandlers = getEventsConfig(props);
   const previousEventHandlers = usePrevious(eventHandlers);

--- a/packages/react-jsx-highcharts/src/utils/debounce-raf.js
+++ b/packages/react-jsx-highcharts/src/utils/debounce-raf.js
@@ -14,12 +14,12 @@ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
 OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 */
 
-export default function(fn) {
+export default function (fn) {
   const cancelAnimationFrame = window.cancelAnimationFrame;
   const requestAnimationFrame = window.requestAnimationFrame;
 
   var queued;
-  return function(...args) {
+  return function (...args) {
     if (queued) cancelAnimationFrame(queued);
 
     queued = requestAnimationFrame(fn.bind(fn, ...args));

--- a/packages/react-jsx-highcharts/src/utils/pickBy.js
+++ b/packages/react-jsx-highcharts/src/utils/pickBy.js
@@ -1,4 +1,4 @@
-export default function(obj, filterFn) {
+export default function (obj, filterFn) {
   let retProps = {};
   if (obj) {
     Object.keys(obj)

--- a/packages/react-jsx-highcharts/test/components/Series/Series.spec.js
+++ b/packages/react-jsx-highcharts/test/components/Series/Series.spec.js
@@ -210,14 +210,26 @@ describe('<Series />', () => {
 
     it('should use the isDataEqual prop to compare data', () => {
       const isDataEqual = jest.fn(() => false);
-      const wrapper = mount(<ProvidedSeries id="mySeries" data={[1, 2, 3]} isDataEqual={isDataEqual} />);
+      const wrapper = mount(
+        <ProvidedSeries
+          id="mySeries"
+          data={[1, 2, 3]}
+          isDataEqual={isDataEqual}
+        />
+      );
       wrapper.setProps({ data: [4, 5, 6] });
       expect(isDataEqual).toHaveBeenCalledWith([4, 5, 6], [1, 2, 3]);
     });
 
     it('should NOT setData if isDataEqual returns true', () => {
       const isDataEqual = jest.fn(() => true);
-      const wrapper = mount(<ProvidedSeries id="mySeries" data={[1, 2, 3]} isDataEqual={isDataEqual} />);
+      const wrapper = mount(
+        <ProvidedSeries
+          id="mySeries"
+          data={[1, 2, 3]}
+          isDataEqual={isDataEqual}
+        />
+      );
       resetMocks();
       wrapper.setProps({ data: [4, 5, 6] });
       expect(testContext.seriesStubs.setData).not.toHaveBeenCalled();
@@ -225,7 +237,13 @@ describe('<Series />', () => {
 
     it('should setData if isDataEqual returns false', () => {
       const isDataEqual = jest.fn(() => false);
-      const wrapper = mount(<ProvidedSeries id="mySeries" data={[1, 2, 3]} isDataEqual={isDataEqual} />);
+      const wrapper = mount(
+        <ProvidedSeries
+          id="mySeries"
+          data={[1, 2, 3]}
+          isDataEqual={isDataEqual}
+        />
+      );
       resetMocks();
       wrapper.setProps({ data: [4, 5, 6] });
       expect(testContext.seriesStubs.setData).toHaveBeenCalled();

--- a/packages/react-jsx-highmaps/package-lock.json
+++ b/packages/react-jsx-highmaps/package-lock.json
@@ -9646,9 +9646,9 @@
       "dev": true
     },
     "prettier": {
-      "version": "1.19.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.19.1.tgz",
-      "integrity": "sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.0.5.tgz",
+      "integrity": "sha512-7PtVymN48hGcO4fGjybyBSIWDsLU4H4XlvOHfq91pz9kkGlonzwTfYkaIEwiRg/dAJF9YlbsduBAgtYLi+8cFg==",
       "dev": true
     },
     "prettier-linter-helpers": {

--- a/packages/react-jsx-highmaps/package.json
+++ b/packages/react-jsx-highmaps/package.json
@@ -71,7 +71,7 @@
     "jest": "^25.4.0",
     "jest-enzyme": "^7.1.2",
     "lodash-webpack-plugin": "^0.11.5",
-    "prettier": "^1.19.1",
+    "prettier": "^2.0.5",
     "prop-types": "^15.7.2",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",

--- a/packages/react-jsx-highmaps/src/components/MapNavigation/MapNavigationZoomIn.js
+++ b/packages/react-jsx-highmaps/src/components/MapNavigation/MapNavigationZoomIn.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import MapNavigationButton from './MapNavigationButton';
 
-const DEFAULT_ONCLICK = function() {
+const DEFAULT_ONCLICK = function () {
   this.mapZoom(0.5);
 };
 

--- a/packages/react-jsx-highmaps/src/components/MapNavigation/MapNavigationZoomOut.js
+++ b/packages/react-jsx-highmaps/src/components/MapNavigation/MapNavigationZoomOut.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import MapNavigationButton from './MapNavigationButton';
 
-const DEFAULT_ONCLICK = function() {
+const DEFAULT_ONCLICK = function () {
   this.mapZoom(2);
 };
 

--- a/packages/react-jsx-highstock/package-lock.json
+++ b/packages/react-jsx-highstock/package-lock.json
@@ -9646,9 +9646,9 @@
       "dev": true
     },
     "prettier": {
-      "version": "1.19.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.19.1.tgz",
-      "integrity": "sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.0.5.tgz",
+      "integrity": "sha512-7PtVymN48hGcO4fGjybyBSIWDsLU4H4XlvOHfq91pz9kkGlonzwTfYkaIEwiRg/dAJF9YlbsduBAgtYLi+8cFg==",
       "dev": true
     },
     "prettier-linter-helpers": {

--- a/packages/react-jsx-highstock/package.json
+++ b/packages/react-jsx-highstock/package.json
@@ -87,7 +87,7 @@
     "jest": "^25.4.0",
     "jest-enzyme": "^7.1.2",
     "lodash-webpack-plugin": "^0.11.5",
-    "prettier": "^1.19.1",
+    "prettier": "^2.0.5",
     "prop-types": "^15.7.2",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",


### PR DESCRIPTION
Upgrade to prettier v2. 

Prettier v2 changed some formatting defaults which I mostly configured back.

Another change is [default endOfLine](https://prettier.io/docs/en/options.html#end-of-line). It can be fixed with either configuring it to auto, or:
> Add * text=auto eol=lf to the repo's .gitattributes file. You may need to ask Windows users to re-clone your repo after this change to ensure git has not converted LF to CRLF on checkout.

Either one is still needed for this PR, which one you prefer?
