### PR TITLE
Expose 'updatePoints' parameter of setData

### DIFF
--- a/packages/react-jsx-highcharts/src/components/Series/Series.js
+++ b/packages/react-jsx-highcharts/src/components/Series/Series.js
@@ -25,6 +25,7 @@ const Series = memo(
     children = null,
     axisId,
     requiresAxis = true,
+    updatePoints = true,
     ...restProps
   }) => {
     const seriesProps = { id, data, type, visible, ...restProps };
@@ -80,7 +81,7 @@ const Series = memo(
       let doRedraw = false;
       // Using setData is more performant than update
       if (isDataEqual(data, prevProps.data) === false) {
-        series.setData(data, false);
+        series.setData(data, false, undefined, updatePoints);
         doRedraw = true;
       }
       if (visible !== prevProps.visible) {
@@ -118,7 +119,8 @@ Series.propTypes = {
   visible: PropTypes.bool,
   children: PropTypes.node,
   axisId: PropTypes.string,
-  requiresAxis: PropTypes.bool
+  requiresAxis: PropTypes.bool,
+  updatePoints: PropTypes.bool
 };
 
 const getSeriesConfig = (props, axis, colorAxis, requiresAxis) => {

--- a/packages/react-jsx-highcharts/src/components/Series/Series.js
+++ b/packages/react-jsx-highcharts/src/components/Series/Series.js
@@ -25,7 +25,7 @@ const Series = memo(
     children = null,
     axisId,
     requiresAxis = true,
-    updatePoints = true,
+    updatePoints,
     ...restProps
   }) => {
     const seriesProps = { id, data, type, visible, ...restProps };

--- a/packages/react-jsx-highcharts/src/components/Series/Series.js
+++ b/packages/react-jsx-highcharts/src/components/Series/Series.js
@@ -25,7 +25,7 @@ const Series = memo(
     children = null,
     axisId,
     requiresAxis = true,
-    updatePoints,
+    jsxOptions,
     ...restProps
   }) => {
     const seriesProps = { id, data, type, visible, ...restProps };
@@ -81,7 +81,9 @@ const Series = memo(
       let doRedraw = false;
       // Using setData is more performant than update
       if (isDataEqual(data, prevProps.data) === false) {
-        series.setData(data, false, undefined, updatePoints);
+        const animation = jsxOptions && jsxOptions.animation;
+        const updatePoints = jsxOptions && jsxOptions.updatePoints;
+        series.setData(data, false, animation, updatePoints);
         doRedraw = true;
       }
       if (visible !== prevProps.visible) {
@@ -120,7 +122,10 @@ Series.propTypes = {
   children: PropTypes.node,
   axisId: PropTypes.string,
   requiresAxis: PropTypes.bool,
-  updatePoints: PropTypes.bool
+  jsxOptions: PropTypes.shape({
+    animation: PropTypes.bool,
+    updatePoints: PropTypes.bool
+  })
 };
 
 const getSeriesConfig = (props, axis, colorAxis, requiresAxis) => {

--- a/packages/react-jsx-highcharts/test/components/Series/Series.spec.js
+++ b/packages/react-jsx-highcharts/test/components/Series/Series.spec.js
@@ -306,7 +306,7 @@ describe('<Series />', () => {
 
     it('should propagate updatePoints when calling setData', () => {
       const wrapper = mount(
-        <ProvidedSeries id="mySeries" data={[]} updatePoints={false} />
+        <ProvidedSeries id="mySeries" data={[]} jsxOptions={{ updatePoints: false }} />
       );
       resetMocks();
       wrapper.setProps({ data: [1, 2, 3] });
@@ -315,6 +315,20 @@ describe('<Series />', () => {
         false,
         undefined,
         false
+      );
+    });
+
+    it('should propagate animation when calling setData', () => {
+      const wrapper = mount(
+        <ProvidedSeries id="mySeries" data={[]} jsxOptions={{ animation: false }} />
+      );
+      resetMocks();
+      wrapper.setProps({ data: [1, 2, 3] });
+      expect(testContext.seriesStubs.setData).toHaveBeenCalledWith(
+        [1, 2, 3],
+        false,
+        false,
+        undefined
       );
     });
   });

--- a/packages/react-jsx-highcharts/test/components/Series/Series.spec.js
+++ b/packages/react-jsx-highcharts/test/components/Series/Series.spec.js
@@ -179,7 +179,9 @@ describe('<Series />', () => {
       wrapper.setProps({ data: [1, 2, 3] });
       expect(testContext.seriesStubs.setData).toHaveBeenCalledWith(
         [1, 2, 3],
-        false
+        false,
+        undefined,
+        undefined
       );
       expect(testContext.seriesStubs.update).not.toHaveBeenCalled();
       expect(testContext.seriesStubs.setVisible).not.toHaveBeenCalled();
@@ -285,7 +287,9 @@ describe('<Series />', () => {
       wrapper.setProps({ opposite: true, data: [4, 5, 6], visible: true });
       expect(testContext.seriesStubs.setData).toHaveBeenCalledWith(
         [4, 5, 6],
-        false
+        false,
+        undefined,
+        undefined
       );
       expect(testContext.seriesStubs.setVisible).toHaveBeenCalledWith(
         true,
@@ -298,6 +302,20 @@ describe('<Series />', () => {
         false
       );
       expect(testContext.needsRedraw).toHaveBeenCalledTimes(1);
+    });
+
+    it('should propagate updatePoints when calling setData', () => {
+      const wrapper = mount(
+        <ProvidedSeries id="mySeries" data={[]} updatePoints={false} />
+      );
+      resetMocks();
+      wrapper.setProps({ data: [1, 2, 3] });
+      expect(testContext.seriesStubs.setData).toHaveBeenCalledWith(
+        [1, 2, 3],
+        false,
+        undefined,
+        false
+      );
     });
   });
 


### PR DESCRIPTION
To allow overriding the default value (true) when calling setData.

In our project, with animations turned off, we don't need to update points for any visual effect and we noticed a huge performance improvement on large data sets with `updatePoints` set to false.

Please let me know if there are other changes throughout the codebase necessary as well and feel free to push updates on this branch.