### PR TITLE
Add containerProps to BaseChart

### DIFF
--- a/packages/react-jsx-highcharts/src/components/BaseChart/BaseChart.js
+++ b/packages/react-jsx-highcharts/src/components/BaseChart/BaseChart.js
@@ -11,6 +11,7 @@ const BaseChart = ({
   children = null,
   callback = noop,
   className = '',
+  containerProps = null,
   ...restProps
 }) => {
   const [rendered, setRendered] = useState(false);
@@ -54,7 +55,7 @@ const BaseChart = ({
   });
 
   return (
-    <div className={`chart ${className}`} ref={domNodeRef}>
+    <div {...containerProps} className={`chart ${className}`} ref={domNodeRef}>
       {rendered && (
         <ChartContext.Provider value={providedChartRef.current}>
           {children}


### PR DESCRIPTION
As discussed [here](https://github.com/whawker/react-jsx-highcharts/issues/282) I add containerProps to BaseChart in order to add style to HighchartsReact and make it responsive relative to parent container.

I tested it and seems is working (with the example reporeted on issue linked before).

Let me know if I need to add more.