### PR TITLE
Fix tooltip not updating properly

### DIFF
--- a/packages/react-jsx-highcharts/src/components/Tooltip/Tooltip.js
+++ b/packages/react-jsx-highcharts/src/components/Tooltip/Tooltip.js
@@ -1,6 +1,6 @@
 import React, { useEffect, memo } from 'react';
 import PropTypes from 'prop-types';
-import { attempt, defaultTo } from 'lodash-es';
+import { attempt } from 'lodash-es';
 import useChart from '../UseChart';
 import useHighcharts from '../UseHighcharts';
 import useModifiedProps from '../UseModifiedProps';
@@ -11,11 +11,10 @@ const Tooltip = memo(props => {
   const chart = useChart();
   const Highcharts = useHighcharts();
 
-  restProps.enabled = defaultTo(props.enabled, true);
+  restProps.enabled = props.enabled ?? true;
 
   useEffect(() => {
-    const chartObj = chart.object;
-    chartObj.tooltip = new Highcharts.Tooltip(chartObj, {
+    updateTooltip(chart, {
       ...(Highcharts.defaultOptions && Highcharts.defaultOptions.tooltip),
       ...restProps
     });
@@ -36,8 +35,9 @@ const Tooltip = memo(props => {
 });
 
 const updateTooltip = (chart, config) => {
-  const tooltip = chart.object.tooltip;
-  tooltip.update(config);
+  chart.update({
+    tooltip: config
+  });
 };
 
 Tooltip.displayName = 'Tooltip';

--- a/packages/react-jsx-highcharts/test/components/Tooltip/Tooltip.spec.js
+++ b/packages/react-jsx-highcharts/test/components/Tooltip/Tooltip.spec.js
@@ -25,17 +25,17 @@ describe('<Tooltip />', () => {
   });
 
   describe('when mounted', () => {
-    it('creates a new Highcharts Tooltip instance', () => {
+    it('enables the tooltip', () => {
       mount(<ProvidedTooltip />);
-      expect(Highcharts.Tooltip).toHaveBeenCalled(); // calledWithNew
+      expect(testContext.chartStubs.update).toHaveBeenCalledWith({
+        tooltip: { enabled: true }
+      });
     });
 
     it('updates the chart with the passed props', () => {
       mount(<ProvidedTooltip backgroundColor="red" shadow={false} />);
-      expect(Highcharts.Tooltip).toHaveBeenCalledWith(testContext.chart, {
-        backgroundColor: 'red',
-        enabled: true,
-        shadow: false
+      expect(testContext.chartStubs.update).toHaveBeenCalledWith({
+        tooltip: { backgroundColor: 'red', enabled: true, shadow: false }
       });
     });
   });
@@ -44,8 +44,8 @@ describe('<Tooltip />', () => {
     it('should use the update method when props change', () => {
       const wrapper = mount(<ProvidedTooltip selected={0} />);
       wrapper.setProps({ padding: 2 });
-      expect(testContext.chart.tooltip.update).toHaveBeenCalledWith({
-        padding: 2
+      expect(testContext.chartStubs.update).toHaveBeenCalledWith({
+        tooltip: { padding: 2 }
       });
     });
   });
@@ -53,9 +53,11 @@ describe('<Tooltip />', () => {
   describe('when unmounted', () => {
     it('should disable the Tooltip', () => {
       const wrapper = mount(<ProvidedTooltip />);
+      testContext.chartStubs.update.mockClear();
       wrapper.unmount();
-      expect(testContext.chart.tooltip.update).toHaveBeenCalledWith({
-        enabled: false
+      expect(testContext.chartStubs.update).toHaveBeenCalledTimes(1);
+      expect(testContext.chartStubs.update).toHaveBeenCalledWith({
+        tooltip: { enabled: false }
       });
     });
   });


### PR DESCRIPTION
This fixes #289.

Now the Tooltip does not get recreated on mount, which might lead to settings leaking from previous tooltip options. But now both pointFormat and enabled props work at the same time.

It might be possible to store chart.options.tooltip.userOptions on mount and restore it on unmount, but that might cause more trouble.

@whawker what do you think?