### PR TITLE
Import react with star import

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -28,7 +28,7 @@
   "rules": {
     "no-unused-vars": [
       "error",
-      { "varsIgnorePattern": "^React$", "ignoreRestSiblings": true }
+      { "ignoreRestSiblings": true }
     ],
     "react/prop-types": "warn",
     "prefer-object-spread": "warn",

--- a/examples/3DChart/App.js
+++ b/examples/3DChart/App.js
@@ -1,4 +1,5 @@
-import React, { Component } from 'react';
+import * as React from 'react';
+import { Component } from 'react';
 import Highcharts from 'highcharts';
 import {
   Highcharts3dChart, Chart, withHighcharts, XAxis, YAxis, ZAxis, Title, Subtitle, ScatterSeries

--- a/examples/3DChart/index.js
+++ b/examples/3DChart/index.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import ReactDOM from 'react-dom';
 import App from './App';
 

--- a/examples/AddSeries/App.js
+++ b/examples/AddSeries/App.js
@@ -1,4 +1,5 @@
-import React, { Component } from 'react';
+import * as React from 'react';
+import { Component } from 'react';
 import Highcharts from 'highcharts';
 import {
   HighchartsChart, withHighcharts, XAxis, YAxis, Title, Legend, LineSeries

--- a/examples/AddSeries/index.js
+++ b/examples/AddSeries/index.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import ReactDOM from 'react-dom';
 import App from './App';
 

--- a/examples/AreaWithAnnotations/App.js
+++ b/examples/AreaWithAnnotations/App.js
@@ -1,4 +1,5 @@
-import React, { Component } from 'react';
+import * as React from 'react';
+import { Component } from 'react';
 import Highcharts from 'highcharts';
 import {
   HighchartsChart,

--- a/examples/AreaWithAnnotations/index.js
+++ b/examples/AreaWithAnnotations/index.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import ReactDOM from 'react-dom';
 import App from './App';
 

--- a/examples/Combo/App.js
+++ b/examples/Combo/App.js
@@ -1,4 +1,5 @@
-import React, { Component } from 'react';
+import * as React from 'react';
+import { Component } from 'react';
 import Highcharts from 'highcharts';
 import {
   HighchartsChart, Chart, withHighcharts, XAxis, YAxis, Title, Legend, ColumnSeries, SplineSeries, PieSeries

--- a/examples/Combo/index.js
+++ b/examples/Combo/index.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import ReactDOM from 'react-dom';
 import App from './App';
 

--- a/examples/CustomComponent/App.js
+++ b/examples/CustomComponent/App.js
@@ -1,4 +1,5 @@
-import React, { Component } from 'react';
+import * as React from 'react';
+import { Component } from 'react';
 import Highcharts from 'highcharts/highstock';
 import {
   HighchartsStockChart, Chart, withHighcharts, XAxis, YAxis, Title, Subtitle, Legend, AreaSplineSeries, Navigator

--- a/examples/CustomComponent/DateRangePickers.js
+++ b/examples/CustomComponent/DateRangePickers.js
@@ -1,4 +1,5 @@
-import React, { useState, useEffect } from 'react';
+import * as React from 'react';
+import { useState, useEffect } from 'react';
 import { useHighcharts, useAxis } from 'react-jsx-highcharts';
 import DayPicker from 'react-day-picker';
 import { parse as dateParse, format as dateFormat, startOfDay } from 'date-fns'

--- a/examples/CustomComponent/exampleCode.js
+++ b/examples/CustomComponent/exampleCode.js
@@ -1,5 +1,6 @@
 export default `
-import React, { useState, useEffect } from 'react';
+import * as React from 'react';
+import { useState, useEffect } from 'react';
 import { useHighcharts, useAxis } from 'react-jsx-highcharts';
 import DayPickerInput from 'react-day-picker/DayPickerInput';
 import dateParse from 'date-fns/parse';

--- a/examples/CustomComponent/index.js
+++ b/examples/CustomComponent/index.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import ReactDOM from 'react-dom';
 import App from './App';
 

--- a/examples/DependencyWheel/App.js
+++ b/examples/DependencyWheel/App.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import Highcharts from 'highcharts';
 import {
   HighchartsChart, withHighcharts, XAxis, YAxis, Title, DependencyWheelSeries, Tooltip

--- a/examples/DependencyWheel/exampleCode.js
+++ b/examples/DependencyWheel/exampleCode.js
@@ -1,5 +1,5 @@
 export default `
-import React from 'react';
+import * as React from 'react';
 import Highcharts from 'highcharts';
 import {
   HighchartsChart, withHighcharts, XAxis, YAxis, Title, SankeySeries, Tooltip

--- a/examples/DependencyWheel/index.js
+++ b/examples/DependencyWheel/index.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import ReactDOM from 'react-dom';
 import App from './App';
 

--- a/examples/Events/App.js
+++ b/examples/Events/App.js
@@ -1,4 +1,5 @@
-import React, { Component } from 'react';
+import * as React from 'react';
+import { Component } from 'react';
 import Highcharts from 'highcharts';
 import {
   HighchartsChart, Chart, withHighcharts, XAxis, YAxis, Title, Legend, ScatterSeries

--- a/examples/Events/index.js
+++ b/examples/Events/index.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import ReactDOM from 'react-dom';
 import App from './App';
 

--- a/examples/Funnel/App.js
+++ b/examples/Funnel/App.js
@@ -1,4 +1,5 @@
-import React, { Component } from 'react';
+import * as React from 'react';
+import { Component } from 'react';
 import Highcharts from 'highcharts';
 import {
   HighchartsChart, withHighcharts, Title, FunnelSeries

--- a/examples/Funnel/index.js
+++ b/examples/Funnel/index.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import ReactDOM from 'react-dom';
 import App from './App';
 

--- a/examples/Gauge/App.js
+++ b/examples/Gauge/App.js
@@ -1,4 +1,5 @@
-import React, { Component } from 'react';
+import * as React from 'react';
+import { Component } from 'react';
 import Highcharts from 'highcharts';
 import {
   HighchartsChart, withHighcharts, XAxis, YAxis, Pane, SolidGaugeSeries

--- a/examples/Gauge/index.js
+++ b/examples/Gauge/index.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import ReactDOM from 'react-dom';
 import App from './App';
 

--- a/examples/HighstockPlotBands/App.js
+++ b/examples/HighstockPlotBands/App.js
@@ -1,4 +1,5 @@
-import React, { Component } from 'react';
+import * as React from 'react';
+import { Component } from 'react';
 import Highcharts from 'highcharts/highstock';
 import {
   HighchartsStockChart, Chart, withHighcharts, XAxis, YAxis, Title, AreaSplineSeries, FlagsSeries, Navigator, PlotBand

--- a/examples/HighstockPlotBands/index.js
+++ b/examples/HighstockPlotBands/index.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import ReactDOM from 'react-dom';
 import App from './App';
 

--- a/examples/Highstocks/App.js
+++ b/examples/Highstocks/App.js
@@ -1,4 +1,5 @@
-import React, { Component } from 'react';
+import * as React from 'react';
+import { Component } from 'react';
 import Highcharts from 'highcharts/highstock';
 import {
   HighchartsStockChart, Chart, withHighcharts, XAxis, YAxis, Title, Legend,

--- a/examples/Highstocks/index.js
+++ b/examples/Highstocks/index.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import ReactDOM from 'react-dom';
 import App from './App';
 

--- a/examples/InvertedChart/App.js
+++ b/examples/InvertedChart/App.js
@@ -1,4 +1,5 @@
-import React, { Component } from 'react';
+import * as React from 'react';
+import { Component } from 'react';
 import Highcharts from 'highcharts';
 import {
   HighchartsChart, Chart, withHighcharts, XAxis, YAxis, Title, Subtitle, AreaSplineSeries, Tooltip

--- a/examples/InvertedChart/index.js
+++ b/examples/InvertedChart/index.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import ReactDOM from 'react-dom';
 import App from './App';
 

--- a/examples/LiveUpdate/App.js
+++ b/examples/LiveUpdate/App.js
@@ -1,4 +1,5 @@
-import React, { Component } from 'react';
+import * as React from 'react';
+import { Component } from 'react';
 import Highcharts from 'highcharts';
 import {
   HighchartsChart, Chart, withHighcharts, XAxis, YAxis, Title, Legend, LineSeries

--- a/examples/LiveUpdate/index.js
+++ b/examples/LiveUpdate/index.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import ReactDOM from 'react-dom';
 import App from './App';
 

--- a/examples/Loading/App.js
+++ b/examples/Loading/App.js
@@ -1,4 +1,5 @@
-import React, { Component } from 'react';
+import * as React from 'react';
+import { Component } from 'react';
 import {
   HighchartsChart, withHighcharts, Title, Subtitle, XAxis, YAxis, LineSeries, Legend, Tooltip, Loading
 } from 'react-jsx-highcharts';

--- a/examples/Loading/index.js
+++ b/examples/Loading/index.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import ReactDOM from 'react-dom';
 import App from './App';
 

--- a/examples/Map/App.js
+++ b/examples/Map/App.js
@@ -1,4 +1,5 @@
-import React, { Component } from 'react'
+import * as React from 'react';
+import { Component } from 'react'
 import { Fetch } from 'react-request'
 import Highmaps from 'highcharts/highmaps'
 import {

--- a/examples/Map/index.js
+++ b/examples/Map/index.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import ReactDOM from 'react-dom';
 import App from './App';
 

--- a/examples/MapBubble/App.js
+++ b/examples/MapBubble/App.js
@@ -1,4 +1,5 @@
-import React, { Component } from 'react'
+import * as React from 'react';
+import { Component } from 'react'
 import { Fetch } from 'react-request'
 import Highmaps from 'highcharts/highmaps'
 import {

--- a/examples/MapBubble/index.js
+++ b/examples/MapBubble/index.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import ReactDOM from 'react-dom';
 import App from './App';
 

--- a/examples/Polar/App.js
+++ b/examples/Polar/App.js
@@ -1,4 +1,5 @@
-import React, { Component } from 'react';
+import * as React from 'react';
+import { Component } from 'react';
 import Highcharts from 'highcharts';
 import {
   HighchartsChart, withHighcharts, XAxis, YAxis, Title, Pane, ColumnSeries, LineSeries, AreaSeries

--- a/examples/Polar/index.js
+++ b/examples/Polar/index.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import ReactDOM from 'react-dom';
 import App from './App';
 

--- a/examples/Reflow/App.js
+++ b/examples/Reflow/App.js
@@ -1,4 +1,5 @@
-import React, { Component } from 'react';
+import * as React from 'react';
+import { Component } from 'react';
 import { Resizable } from 're-resizable';
 import Highcharts from 'highcharts';
 import {

--- a/examples/Reflow/index.js
+++ b/examples/Reflow/index.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import ReactDOM from 'react-dom';
 import App from './App';
 

--- a/examples/Responsive/App.js
+++ b/examples/Responsive/App.js
@@ -1,4 +1,5 @@
-import React, { Component } from 'react';
+import * as React from 'react';
+import { Component } from 'react';
 import LeagueTableChart from './LeagueTableChart';
 import ExampleCode from '../utils/ExampleCode';
 import code from './exampleCode';

--- a/examples/Responsive/LeagueTableChart.js
+++ b/examples/Responsive/LeagueTableChart.js
@@ -1,4 +1,5 @@
-import React, { Component } from 'react';
+import * as React from 'react';
+import { Component } from 'react';
 import Highcharts from 'highcharts';
 import {
   HighchartsChart,

--- a/examples/Responsive/LeagueTableSection.js
+++ b/examples/Responsive/LeagueTableSection.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { PlotBand } from 'react-jsx-highcharts';
 
 const LABEL_STYLE = {color: "#aaa"};

--- a/examples/Responsive/TeamSeries.js
+++ b/examples/Responsive/TeamSeries.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { SplineSeries } from 'react-jsx-highcharts';
 
 const TeamSeries = ({ name, color, matchWeek, onClick, ...rest }) => (

--- a/examples/Responsive/index.js
+++ b/examples/Responsive/index.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import ReactDOM from 'react-dom';
 import App from './App';
 

--- a/examples/Sankey/App.js
+++ b/examples/Sankey/App.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import Highcharts from 'highcharts';
 import {
   HighchartsChart, withHighcharts, XAxis, YAxis, Title, SankeySeries, Tooltip

--- a/examples/Sankey/exampleCode.js
+++ b/examples/Sankey/exampleCode.js
@@ -1,5 +1,5 @@
 export default `
-import React from 'react';
+import * as React from 'react';
 import Highcharts from 'highcharts';
 import {
   HighchartsChart, withHighcharts, XAxis, YAxis, Title, SankeySeries, Tooltip

--- a/examples/Sankey/index.js
+++ b/examples/Sankey/index.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import ReactDOM from 'react-dom';
 import App from './App';
 

--- a/examples/SimpleLine/App.js
+++ b/examples/SimpleLine/App.js
@@ -1,4 +1,5 @@
-import React, { Component } from 'react';
+import * as React from 'react';
+import { Component } from 'react';
 import Highcharts from 'highcharts';
 import {
   HighchartsChart, Chart, withHighcharts, XAxis, YAxis, Title, Subtitle, Legend, LineSeries, Caption

--- a/examples/SimpleLine/exampleCode.js
+++ b/examples/SimpleLine/exampleCode.js
@@ -1,5 +1,6 @@
 export default `
-import React, { Component } from 'react';
+import * as React from 'react';
+import { Component } from 'react';
 import Highcharts from 'highcharts';
 import {
   HighchartsChart, Chart, withHighcharts, XAxis, YAxis, Title, Subtitle, Legend, LineSeries, Caption

--- a/examples/SimpleLine/index.js
+++ b/examples/SimpleLine/index.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import ReactDOM from 'react-dom';
 import App from './App';
 

--- a/examples/Sparkline/App.js
+++ b/examples/Sparkline/App.js
@@ -1,4 +1,5 @@
-import React, { Component } from 'react';
+import * as React from 'react';
+import { Component } from 'react';
 import {
   HighchartsSparkline, withHighcharts, AreaSeries, Tooltip
 } from 'react-jsx-highcharts';

--- a/examples/Sparkline/index.js
+++ b/examples/Sparkline/index.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import ReactDOM from 'react-dom';
 import App from './App';
 

--- a/examples/SplineWithPlotBands/App.js
+++ b/examples/SplineWithPlotBands/App.js
@@ -1,4 +1,5 @@
-import React, { Component } from 'react';
+import * as React from 'react';
+import { Component } from 'react';
 import Highcharts from 'highcharts';
 import {
   HighchartsChart, Chart, withHighcharts, XAxis, YAxis, Title, Subtitle, PlotBand, Legend, SplineSeries, Tooltip

--- a/examples/SplineWithPlotBands/index.js
+++ b/examples/SplineWithPlotBands/index.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import ReactDOM from 'react-dom';
 import App from './App';
 

--- a/examples/StreamGraph/App.js
+++ b/examples/StreamGraph/App.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import Highcharts from 'highcharts';
 import {
   HighchartsChart, withHighcharts, Chart, XAxis, YAxis, Title, Subtitle, StreamGraphSeries, Tooltip

--- a/examples/StreamGraph/index.js
+++ b/examples/StreamGraph/index.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import ReactDOM from 'react-dom';
 import App from './App';
 

--- a/examples/StyleByCSS/App.js
+++ b/examples/StyleByCSS/App.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import Highcharts from 'highcharts';
 import {
   HighchartsChart, Chart, withHighcharts, XAxis, YAxis, Title, Subtitle, Tooltip, Legend, LineSeries

--- a/examples/StyleByCSS/index.js
+++ b/examples/StyleByCSS/index.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import ReactDOM from 'react-dom';
 import App from './App';
 

--- a/examples/SynchronisedCharts/App.js
+++ b/examples/SynchronisedCharts/App.js
@@ -1,4 +1,5 @@
-import React, { Component } from 'react';
+import * as React from 'react';
+import { Component } from 'react';
 import Highcharts from 'highcharts';
 import {
   HighchartsChart, withHighcharts, XAxis, YAxis, Title, Series, Tooltip

--- a/examples/SynchronisedCharts/index.js
+++ b/examples/SynchronisedCharts/index.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import ReactDOM from 'react-dom';
 import App from './App';
 

--- a/examples/ToggleAxis/App.js
+++ b/examples/ToggleAxis/App.js
@@ -1,4 +1,5 @@
-import React, {Component} from 'react';
+import * as React from 'react';
+import {Component} from 'react';
 import highcharts from 'highcharts';
 import { HighchartsChart, Chart, XAxis, YAxis, LineSeries, withHighcharts } from 'react-jsx-highcharts';
 

--- a/examples/ToggleAxis/index.js
+++ b/examples/ToggleAxis/index.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import ReactDOM from 'react-dom';
 import App from './App';
 

--- a/examples/Treemap/App.js
+++ b/examples/Treemap/App.js
@@ -1,4 +1,5 @@
-import React, { Component } from 'react';
+import * as React from 'react';
+import { Component } from 'react';
 import Highcharts from 'highcharts';
 import {
   HighchartsChart, withHighcharts, Title, XAxis, YAxis, TreemapSeries, Legend

--- a/examples/Treemap/index.js
+++ b/examples/Treemap/index.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import ReactDOM from 'react-dom';
 import App from './App';
 

--- a/examples/TreemapDrilldown/App.js
+++ b/examples/TreemapDrilldown/App.js
@@ -1,4 +1,5 @@
-import React, { Component } from 'react';
+import * as React from 'react';
+import { Component } from 'react';
 import Highcharts from 'highcharts';
 import {
   HighchartsChart, withHighcharts, Title, Subtitle, XAxis, YAxis, TreemapSeries, Tooltip

--- a/examples/TreemapDrilldown/index.js
+++ b/examples/TreemapDrilldown/index.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import ReactDOM from 'react-dom';
 import App from './App';
 

--- a/examples/UpdateChart/App.js
+++ b/examples/UpdateChart/App.js
@@ -1,4 +1,5 @@
-import React, { Component } from 'react';
+import * as React from 'react';
+import { Component } from 'react';
 import Highcharts from 'highcharts';
 import {
   HighchartsChart, withHighcharts, Chart, XAxis, YAxis, Title, Legend, LineSeries

--- a/examples/UpdateChart/index.js
+++ b/examples/UpdateChart/index.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import ReactDOM from 'react-dom';
 import App from './App';
 

--- a/examples/UpdateWithEvents/App.js
+++ b/examples/UpdateWithEvents/App.js
@@ -1,4 +1,5 @@
-import React, { Component } from 'react';
+import * as React from 'react';
+import { Component } from 'react';
 import MyChart from './MyChart';
 
 const data1 = [1, 2, 3, 4, 5];

--- a/examples/UpdateWithEvents/MyChart.js
+++ b/examples/UpdateWithEvents/MyChart.js
@@ -1,4 +1,5 @@
-import React, { Component } from 'react';
+import * as React from 'react';
+import { Component } from 'react';
 import Highcharts from 'highcharts';
 import {
   HighchartsChart,

--- a/examples/UpdateWithEvents/index.js
+++ b/examples/UpdateWithEvents/index.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import ReactDOM from 'react-dom';
 import App from './App';
 

--- a/packages/react-jsx-highcharts/src/components/Annotation/Annotation.js
+++ b/packages/react-jsx-highcharts/src/components/Annotation/Annotation.js
@@ -1,4 +1,4 @@
-import React, { useRef, useEffect, memo } from 'react';
+import { useRef, useEffect, memo } from 'react';
 import PropTypes from 'prop-types';
 import { v4 as uuid } from 'uuid';
 import { attempt } from 'lodash-es';

--- a/packages/react-jsx-highcharts/src/components/Axis/Axis.js
+++ b/packages/react-jsx-highcharts/src/components/Axis/Axis.js
@@ -1,4 +1,5 @@
-import React, { useEffect, useState, useRef } from 'react';
+import * as React from 'react';
+import { useEffect, useState, useRef } from 'react';
 import PropTypes from 'prop-types';
 import { v4 as uuid } from 'uuid';
 import { attempt } from 'lodash-es';

--- a/packages/react-jsx-highcharts/src/components/BarSeries/BarSeries.js
+++ b/packages/react-jsx-highcharts/src/components/BarSeries/BarSeries.js
@@ -1,4 +1,5 @@
-import React, { useEffect } from 'react';
+import * as React from 'react';
+import { useEffect } from 'react';
 import PropTypes from 'prop-types';
 import Series from '../Series';
 import useChart from '../UseChart';

--- a/packages/react-jsx-highcharts/src/components/BaseChart/BaseChart.js
+++ b/packages/react-jsx-highcharts/src/components/BaseChart/BaseChart.js
@@ -1,4 +1,5 @@
-import React, { useState, useEffect, useRef, useLayoutEffect } from 'react';
+import * as React from 'react';
+import { useState, useEffect, useRef, useLayoutEffect } from 'react';
 import PropTypes from 'prop-types';
 import ChartContext from '../ChartContext';
 import usePrevious from '../UsePrevious';

--- a/packages/react-jsx-highcharts/src/components/ColorAxis/ColorAxis.js
+++ b/packages/react-jsx-highcharts/src/components/ColorAxis/ColorAxis.js
@@ -1,4 +1,5 @@
-import React, { useEffect, useRef, useState } from 'react';
+import * as React from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { v4 as uuid } from 'uuid';
 import { attempt } from 'lodash-es';
 import { getNonEventHandlerProps, getEventsConfig } from '../../utils/events';

--- a/packages/react-jsx-highcharts/src/components/Debug/Debug.js
+++ b/packages/react-jsx-highcharts/src/components/Debug/Debug.js
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import { useEffect } from 'react';
 import PropTypes from 'prop-types';
 import useChart from '../UseChart';
 

--- a/packages/react-jsx-highcharts/src/components/Highcharts3dChart/Highcharts3dChart.js
+++ b/packages/react-jsx-highcharts/src/components/Highcharts3dChart/Highcharts3dChart.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import HighchartsChart from '../HighchartsChart';
 import Options3d from '../Options3d';
 

--- a/packages/react-jsx-highcharts/src/components/HighchartsChart/HighchartsChart.js
+++ b/packages/react-jsx-highcharts/src/components/HighchartsChart/HighchartsChart.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import BaseChart from '../BaseChart';
 import useHighcharts from '../UseHighcharts';
 

--- a/packages/react-jsx-highcharts/src/components/HighchartsSparkline/HighchartsSparkline.js
+++ b/packages/react-jsx-highcharts/src/components/HighchartsSparkline/HighchartsSparkline.js
@@ -1,4 +1,5 @@
-import React, { useMemo } from 'react';
+import * as React from 'react';
+import { useMemo } from 'react';
 import PropTypes from 'prop-types';
 import HighchartsChart from '../HighchartsChart';
 import Chart from '../Chart';

--- a/packages/react-jsx-highcharts/src/components/Options3d/Options3d.js
+++ b/packages/react-jsx-highcharts/src/components/Options3d/Options3d.js
@@ -1,4 +1,4 @@
-import React, { useEffect, memo } from 'react';
+import { useEffect, memo } from 'react';
 import PropTypes from 'prop-types';
 import { log3DModuleErrorMessage } from '../../utils/warnings';
 import useHighcharts from '../UseHighcharts';

--- a/packages/react-jsx-highcharts/src/components/PlotBandLine/PlotBand.js
+++ b/packages/react-jsx-highcharts/src/components/PlotBandLine/PlotBand.js
@@ -1,4 +1,5 @@
-import React, { memo } from 'react';
+import * as React from 'react';
+import { memo } from 'react';
 import PropTypes from 'prop-types';
 import PlotBandLineContext from '../PlotBandLineContext';
 import usePlotBandLineLifecycle from './UsePlotBandLineLifecycle';

--- a/packages/react-jsx-highcharts/src/components/PlotBandLine/PlotLine.js
+++ b/packages/react-jsx-highcharts/src/components/PlotBandLine/PlotLine.js
@@ -1,4 +1,5 @@
-import React, { memo } from 'react';
+import * as React from 'react';
+import { memo } from 'react';
 import PropTypes from 'prop-types';
 import PlotBandLineContext from '../PlotBandLineContext';
 import usePlotBandLineLifecycle from './UsePlotBandLineLifecycle';

--- a/packages/react-jsx-highcharts/src/components/PlotBandLine/UsePlotBandLineLifecycle.js
+++ b/packages/react-jsx-highcharts/src/components/PlotBandLine/UsePlotBandLineLifecycle.js
@@ -1,4 +1,4 @@
-import React, { useRef, useEffect, useState } from 'react';
+import { useRef, useEffect, useState } from 'react';
 import { v4 as uuid } from 'uuid';
 import { attempt } from 'lodash-es';
 import useModifiedProps from '../UseModifiedProps';

--- a/packages/react-jsx-highcharts/src/components/Series/Series.js
+++ b/packages/react-jsx-highcharts/src/components/Series/Series.js
@@ -1,4 +1,5 @@
-import React, { memo, useRef, useState, useEffect } from 'react';
+import * as React from 'react';
+import { memo, useRef, useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { v4 as uuid } from 'uuid';
 import { attempt } from 'lodash-es';

--- a/packages/react-jsx-highcharts/src/components/Tooltip/Tooltip.js
+++ b/packages/react-jsx-highcharts/src/components/Tooltip/Tooltip.js
@@ -1,4 +1,4 @@
-import React, { useEffect, memo } from 'react';
+import { useEffect, memo } from 'react';
 import PropTypes from 'prop-types';
 import { attempt, defaultTo } from 'lodash-es';
 import useChart from '../UseChart';

--- a/packages/react-jsx-highcharts/src/components/WithHighcharts/index.js
+++ b/packages/react-jsx-highcharts/src/components/WithHighcharts/index.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import HighchartsContext from '../HighchartsContext';
 
 // This is a HOC function.

--- a/packages/react-jsx-highcharts/src/components/WithSeriesType/index.js
+++ b/packages/react-jsx-highcharts/src/components/WithSeriesType/index.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import PropTypes from 'prop-types';
 import Series from '../Series';
 

--- a/packages/react-jsx-highcharts/src/components/XAxis/XAxis.js
+++ b/packages/react-jsx-highcharts/src/components/XAxis/XAxis.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import Axis from '../Axis';
 import useChart from '../UseChart';
 

--- a/packages/react-jsx-highcharts/src/components/YAxis/YAxis.js
+++ b/packages/react-jsx-highcharts/src/components/YAxis/YAxis.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import PropTypes from 'prop-types';
 import Axis from '../Axis';
 

--- a/packages/react-jsx-highcharts/src/components/ZAxis/ZAxis.js
+++ b/packages/react-jsx-highcharts/src/components/ZAxis/ZAxis.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import PropTypes from 'prop-types';
 import Axis from '../Axis';
 

--- a/packages/react-jsx-highcharts/test/components/Annotation/Annotation.spec.js
+++ b/packages/react-jsx-highcharts/test/components/Annotation/Annotation.spec.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { createMockProvidedChart, uuidRegex } from '../../test-utils';
 import Annotation from '../../../src/components/Annotation/Annotation';
 import ChartContext from '../../../src/components/ChartContext';

--- a/packages/react-jsx-highcharts/test/components/Axis/Axis.integration.spec.js
+++ b/packages/react-jsx-highcharts/test/components/Axis/Axis.integration.spec.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import Highcharts from 'highcharts';
 import { HighchartsChart, withHighcharts } from '../../../src';
 import Axis from '../../../src/components/Axis';

--- a/packages/react-jsx-highcharts/test/components/Axis/Axis.spec.js
+++ b/packages/react-jsx-highcharts/test/components/Axis/Axis.spec.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import {
   createMockProvidedChart,
   createMockAxis,

--- a/packages/react-jsx-highcharts/test/components/Axis/AxisTitle.spec.js
+++ b/packages/react-jsx-highcharts/test/components/Axis/AxisTitle.spec.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { createMockProvidedAxis } from '../../test-utils';
 import AxisTitle from '../../../src/components/Axis/AxisTitle';
 import * as useAxis from '../../../src/components/UseAxis';

--- a/packages/react-jsx-highcharts/test/components/BarSeries/BarSeries.spec.js
+++ b/packages/react-jsx-highcharts/test/components/BarSeries/BarSeries.spec.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import {
   createMockProvidedChart,
   createMockProvidedAxis

--- a/packages/react-jsx-highcharts/test/components/BaseChart/BaseChart.spec.js
+++ b/packages/react-jsx-highcharts/test/components/BaseChart/BaseChart.spec.js
@@ -1,4 +1,5 @@
-import React, { Component, cloneElement } from 'react';
+import * as React from 'react';
+import { Component, cloneElement } from 'react';
 import BaseChart from '../../../src/components/BaseChart';
 import ChartContext from '../../../src/components/ChartContext';
 import { createMockChart } from '../../test-utils';

--- a/packages/react-jsx-highcharts/test/components/Caption/Caption.spec.js
+++ b/packages/react-jsx-highcharts/test/components/Caption/Caption.spec.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { createMockProvidedChart } from '../../test-utils';
 import Caption from '../../../src/components/Caption/Caption';
 import ChartContext from '../../../src/components/ChartContext';

--- a/packages/react-jsx-highcharts/test/components/Chart/Chart.spec.js
+++ b/packages/react-jsx-highcharts/test/components/Chart/Chart.spec.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { createMockProvidedChart, Highcharts } from '../../test-utils';
 import Chart from '../../../src/components/Chart/Chart';
 import ChartContext from '../../../src/components/ChartContext';

--- a/packages/react-jsx-highcharts/test/components/ColorAxis/ColorAxis.integration.spec.js
+++ b/packages/react-jsx-highcharts/test/components/ColorAxis/ColorAxis.integration.spec.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import Highcharts from 'highcharts';
 import addColorAxis from 'highcharts/modules/coloraxis';
 import { HighchartsChart, withHighcharts } from '../../../src';

--- a/packages/react-jsx-highcharts/test/components/Credits/Credits.spec.js
+++ b/packages/react-jsx-highcharts/test/components/Credits/Credits.spec.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { createMockProvidedChart, Highcharts } from '../../test-utils';
 import Credits from '../../../src/components/Credits/Credits';
 import ChartContext from '../../../src/components/ChartContext';

--- a/packages/react-jsx-highcharts/test/components/HighchartsChart/HighchartsChart.spec.js
+++ b/packages/react-jsx-highcharts/test/components/HighchartsChart/HighchartsChart.spec.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { Highcharts, createMockChart } from '../../test-utils';
 import HighchartsChart from '../../../src/components/HighchartsChart/HighchartsChart';
 import BaseChart from '../../../src/components/BaseChart';

--- a/packages/react-jsx-highcharts/test/components/Legend/Legend.spec.js
+++ b/packages/react-jsx-highcharts/test/components/Legend/Legend.spec.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { createMockProvidedChart } from '../../test-utils';
 import Legend from '../../../src/components/Legend/Legend';
 import ChartContext from '../../../src/components/ChartContext';

--- a/packages/react-jsx-highcharts/test/components/Legend/LegendTitle.spec.js
+++ b/packages/react-jsx-highcharts/test/components/Legend/LegendTitle.spec.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import LegendTitle from '../../../src/components/Legend/LegendTitle';
 import { createMockProvidedChart } from '../../test-utils';
 import ChartContext from '../../../src/components/ChartContext';

--- a/packages/react-jsx-highcharts/test/components/Loading/Loading.spec.js
+++ b/packages/react-jsx-highcharts/test/components/Loading/Loading.spec.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { createMockProvidedChart } from '../../test-utils';
 import Loading from '../../../src/components/Loading/Loading';
 import ChartContext from '../../../src/components/ChartContext';

--- a/packages/react-jsx-highcharts/test/components/Options3d/Options3d.spec.js
+++ b/packages/react-jsx-highcharts/test/components/Options3d/Options3d.spec.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { createMockProvidedChart } from '../../test-utils';
 import Options3d from '../../../src/components/Options3d/Options3d';
 import ChartContext from '../../../src/components/ChartContext';

--- a/packages/react-jsx-highcharts/test/components/Pane/Pane.spec.js
+++ b/packages/react-jsx-highcharts/test/components/Pane/Pane.spec.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { createMockProvidedChart } from '../../test-utils';
 import Pane from '../../../src/components/Pane/Pane';
 import ChartContext from '../../../src/components/ChartContext';

--- a/packages/react-jsx-highcharts/test/components/PlotBandLine/PlotBand.integration.spec.js
+++ b/packages/react-jsx-highcharts/test/components/PlotBandLine/PlotBand.integration.spec.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import Highcharts from 'highcharts';
 import {
   HighchartsChart,

--- a/packages/react-jsx-highcharts/test/components/PlotBandLine/PlotBandLineLabel.integration.spec.js
+++ b/packages/react-jsx-highcharts/test/components/PlotBandLine/PlotBandLineLabel.integration.spec.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import Highcharts from 'highcharts';
 import {
   HighchartsChart,

--- a/packages/react-jsx-highcharts/test/components/PlotBandLine/PlotBandLineLabel.spec.js
+++ b/packages/react-jsx-highcharts/test/components/PlotBandLine/PlotBandLineLabel.spec.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import PlotBandLineLabel from '../../../src/components/PlotBandLine/PlotBandLineLabel';
 import PlotLineContext from '../../../src/components/PlotBandLineContext';
 

--- a/packages/react-jsx-highcharts/test/components/PlotBandLine/PlotLine.spec.js
+++ b/packages/react-jsx-highcharts/test/components/PlotBandLine/PlotLine.spec.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { createMockProvidedAxis, uuidRegex } from '../../test-utils';
 import PlotLine from '../../../src/components/PlotBandLine/PlotLine';
 import * as useAxis from '../../../src/components/UseAxis';

--- a/packages/react-jsx-highcharts/test/components/Series/Series.spec.js
+++ b/packages/react-jsx-highcharts/test/components/Series/Series.spec.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import {
   Highcharts,
   createMockProvidedChart,

--- a/packages/react-jsx-highcharts/test/components/Series/SeriesTypes.integration.spec.js
+++ b/packages/react-jsx-highcharts/test/components/Series/SeriesTypes.integration.spec.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import Highcharts from 'highcharts';
 
 import addHighchartsMore from 'highcharts/highcharts-more';

--- a/packages/react-jsx-highcharts/test/components/Series/SeriesTypes.spec.js
+++ b/packages/react-jsx-highcharts/test/components/Series/SeriesTypes.spec.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import Highcharts from 'highcharts';
 
 import * as all from '../../../src';

--- a/packages/react-jsx-highcharts/test/components/Subtitle/Subtitle.spec.js
+++ b/packages/react-jsx-highcharts/test/components/Subtitle/Subtitle.spec.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { createMockProvidedChart } from '../../test-utils';
 import Subtitle from '../../../src/components/Subtitle/Subtitle';
 import ChartContext from '../../../src/components/ChartContext';

--- a/packages/react-jsx-highcharts/test/components/Title/Title.spec.js
+++ b/packages/react-jsx-highcharts/test/components/Title/Title.spec.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { createMockProvidedChart } from '../../test-utils';
 import Title from '../../../src/components/Title/Title';
 import ChartContext from '../../../src/components/ChartContext';

--- a/packages/react-jsx-highcharts/test/components/Tooltip/Tooltip.spec.js
+++ b/packages/react-jsx-highcharts/test/components/Tooltip/Tooltip.spec.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { Highcharts, createMockProvidedChart } from '../../test-utils';
 import Tooltip from '../../../src/components/Tooltip/Tooltip';
 import HighchartsContext from '../../../src/components/HighchartsContext';

--- a/packages/react-jsx-highcharts/test/components/UseAxis/useAxis.spec.js
+++ b/packages/react-jsx-highcharts/test/components/UseAxis/useAxis.spec.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { act } from 'react-dom/test-utils';
 import useAxis from '../../../src/components/UseAxis';
 import AxisContext from '../../../src/components/AxisContext';

--- a/packages/react-jsx-highcharts/test/components/UseChart/useChart.spec.js
+++ b/packages/react-jsx-highcharts/test/components/UseChart/useChart.spec.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import useChart from '../../../src/components/UseChart';
 import ChartContext from '../../../src/components/ChartContext';
 

--- a/packages/react-jsx-highcharts/test/components/UseChartUpdate/useChartUpdate.spec.js
+++ b/packages/react-jsx-highcharts/test/components/UseChartUpdate/useChartUpdate.spec.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import useChartUpdate from '../../../src/components/UseChartUpdate';
 import ChartContext from '../../../src/components/ChartContext';
 import { createMockProvidedChart } from '../../test-utils';

--- a/packages/react-jsx-highcharts/test/components/UseHighcharts/useHighcharts.spec.js
+++ b/packages/react-jsx-highcharts/test/components/UseHighcharts/useHighcharts.spec.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import useHighcharts from '../../../src/components/UseHighcharts';
 import HighchartsContext from '../../../src/components/HighchartsContext';
 import { Highcharts } from '../../test-utils';

--- a/packages/react-jsx-highcharts/test/components/UseManualEventHandlers/useManualEventHandlers.spec.js
+++ b/packages/react-jsx-highcharts/test/components/UseManualEventHandlers/useManualEventHandlers.spec.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import useManualEventHandlers from '../../../src/components/UseManualEventHandlers';
 
 import { Highcharts } from '../../test-utils';

--- a/packages/react-jsx-highcharts/test/components/UseModifiedProps/useModifiedProps.spec.js
+++ b/packages/react-jsx-highcharts/test/components/UseModifiedProps/useModifiedProps.spec.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import useModifiedProps from '../../../src/components/UseModifiedProps';
 
 describe('useChartUpdate', () => {

--- a/packages/react-jsx-highcharts/test/components/UsePlotBandLine/usePlotBandLine.spec.js
+++ b/packages/react-jsx-highcharts/test/components/UsePlotBandLine/usePlotBandLine.spec.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import usePlotBandLine from '../../../src/components/UsePlotBandLine';
 import PlotBandLineContext from '../../../src/components/PlotBandLineContext';
 

--- a/packages/react-jsx-highcharts/test/components/UseSeries/useSeries.spec.js
+++ b/packages/react-jsx-highcharts/test/components/UseSeries/useSeries.spec.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { act } from 'react-dom/test-utils';
 import useSeries from '../../../src/components/UseSeries';
 import SeriesContext from '../../../src/components/SeriesContext';

--- a/packages/react-jsx-highcharts/test/components/WithHighcharts/index.spec.js
+++ b/packages/react-jsx-highcharts/test/components/WithHighcharts/index.spec.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import withHighcharts from '../../../src/components/WithHighcharts';
 import HighchartsContext from '../../../src/components/HighchartsContext';
 import { Highcharts } from '../../test-utils';

--- a/packages/react-jsx-highcharts/test/components/WithSeriesType/index.spec.js
+++ b/packages/react-jsx-highcharts/test/components/WithSeriesType/index.spec.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import PropTypes from 'prop-types';
 import withSeriesType from '../../../src/components/WithSeriesType';
 import Series from '../../../src/components/Series';

--- a/packages/react-jsx-highcharts/test/components/XAxis/XAxis.spec.js
+++ b/packages/react-jsx-highcharts/test/components/XAxis/XAxis.spec.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import XAxis from '../../../src/components/XAxis/XAxis';
 import Axis from '../../../src/components/Axis';
 import ChartContext from '../../../src/components/ChartContext';

--- a/packages/react-jsx-highcharts/test/components/YAxis/YAxis.spec.js
+++ b/packages/react-jsx-highcharts/test/components/YAxis/YAxis.spec.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import YAxis from '../../../src/components/YAxis/YAxis';
 import Axis from '../../../src/components/Axis';
 

--- a/packages/react-jsx-highcharts/test/components/ZAxis/ZAxis.spec.js
+++ b/packages/react-jsx-highcharts/test/components/ZAxis/ZAxis.spec.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import ZAxis from '../../../src/components/ZAxis/ZAxis';
 import Axis from '../../../src/components/Axis';
 

--- a/packages/react-jsx-highmaps/src/components/HighchartsMapChart/HighchartsMapChart.js
+++ b/packages/react-jsx-highmaps/src/components/HighchartsMapChart/HighchartsMapChart.js
@@ -1,4 +1,5 @@
-import React, { useMemo, useCallback } from 'react';
+import * as React from 'react';
+import { useMemo, useCallback } from 'react';
 import { BaseChart, useHighcharts } from 'react-jsx-highcharts';
 
 const XAXIS = { id: 'xAxis' };

--- a/packages/react-jsx-highmaps/src/components/MapNavigation/MapNavigation.js
+++ b/packages/react-jsx-highmaps/src/components/MapNavigation/MapNavigation.js
@@ -1,4 +1,5 @@
-import React, { useEffect, useState } from 'react';
+import * as React from 'react';
+import { useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
 import { attempt } from 'lodash-es';
 import {

--- a/packages/react-jsx-highmaps/src/components/MapNavigation/MapNavigationZoomIn.js
+++ b/packages/react-jsx-highmaps/src/components/MapNavigation/MapNavigationZoomIn.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import MapNavigationButton from './MapNavigationButton';
 
 const DEFAULT_ONCLICK = function () {

--- a/packages/react-jsx-highmaps/src/components/MapNavigation/MapNavigationZoomOut.js
+++ b/packages/react-jsx-highmaps/src/components/MapNavigation/MapNavigationZoomOut.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import MapNavigationButton from './MapNavigationButton';
 
 const DEFAULT_ONCLICK = function () {

--- a/packages/react-jsx-highmaps/src/components/XAxis/XAxis.js
+++ b/packages/react-jsx-highmaps/src/components/XAxis/XAxis.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { XAxis } from 'react-jsx-highcharts';
 
 const MapXAxis = ({

--- a/packages/react-jsx-highmaps/src/components/YAxis/YAxis.js
+++ b/packages/react-jsx-highmaps/src/components/YAxis/YAxis.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { YAxis } from 'react-jsx-highcharts';
 
 const MapYAxis = ({

--- a/packages/react-jsx-highmaps/test/components/HighchartsMapChart/HighchartsMapChart.spec.js
+++ b/packages/react-jsx-highmaps/test/components/HighchartsMapChart/HighchartsMapChart.spec.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 
 jest.mock('react-jsx-highcharts', () => ({
   ...jest.requireActual('react-jsx-highcharts'),

--- a/packages/react-jsx-highmaps/test/components/XAxis/XAxis.spec.js
+++ b/packages/react-jsx-highmaps/test/components/XAxis/XAxis.spec.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { XAxis } from 'react-jsx-highcharts';
 import MapXAxis from '../../../src/components/XAxis';
 

--- a/packages/react-jsx-highmaps/test/components/YAxis/YAxis.spec.js
+++ b/packages/react-jsx-highmaps/test/components/YAxis/YAxis.spec.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { YAxis } from 'react-jsx-highcharts';
 import MapYAxis from '../../../src/components/YAxis';
 

--- a/packages/react-jsx-highstock/src/components/HighchartsStockChart/HighchartsStockChart.js
+++ b/packages/react-jsx-highstock/src/components/HighchartsStockChart/HighchartsStockChart.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { BaseChart, useHighcharts } from 'react-jsx-highcharts';
 
 const HighchartsStockChart = props => {

--- a/packages/react-jsx-highstock/src/components/Navigator/Navigator.js
+++ b/packages/react-jsx-highstock/src/components/Navigator/Navigator.js
@@ -1,4 +1,5 @@
-import React, { useState, useEffect } from 'react';
+import * as React from 'react';
+import { useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { attempt } from 'lodash-es';
 import {

--- a/packages/react-jsx-highstock/src/components/Navigator/NavigatorAxis.js
+++ b/packages/react-jsx-highstock/src/components/Navigator/NavigatorAxis.js
@@ -1,4 +1,5 @@
-import React, {
+import * as React from 'react';
+import {
   useRef,
   useEffect,
   Children,

--- a/packages/react-jsx-highstock/src/components/Navigator/NavigatorXAxis.js
+++ b/packages/react-jsx-highstock/src/components/Navigator/NavigatorXAxis.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import NavigatorAxis from './NavigatorAxis';
 
 const NavigatorXAxis = props => (

--- a/packages/react-jsx-highstock/src/components/Navigator/NavigatorYAxis.js
+++ b/packages/react-jsx-highstock/src/components/Navigator/NavigatorYAxis.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import NavigatorAxis from './NavigatorAxis';
 
 const NavigatorYAxis = props => (

--- a/packages/react-jsx-highstock/src/components/RangeSelector/RangeSelector.js
+++ b/packages/react-jsx-highstock/src/components/RangeSelector/RangeSelector.js
@@ -1,4 +1,5 @@
-import React, { useState, useEffect } from 'react';
+import * as React from 'react';
+import { useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { attempt } from 'lodash-es';
 import {

--- a/packages/react-jsx-highstock/src/components/Scrollbar/Scrollbar.js
+++ b/packages/react-jsx-highstock/src/components/Scrollbar/Scrollbar.js
@@ -1,4 +1,5 @@
-import React, { useEffect } from 'react';
+import * as React from 'react';
+import { useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { attempt } from 'lodash-es';
 import { useModifiedProps, useChart } from 'react-jsx-highcharts';

--- a/packages/react-jsx-highstock/test/components/HighchartsStockChart/HighchartsStockChart.spec.js
+++ b/packages/react-jsx-highstock/test/components/HighchartsStockChart/HighchartsStockChart.spec.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 
 jest.mock('react-jsx-highcharts', () => ({
   ...jest.requireActual('react-jsx-highcharts'),

--- a/packages/react-jsx-highstock/test/components/Navigator/Navigator.integration.spec.js
+++ b/packages/react-jsx-highstock/test/components/Navigator/Navigator.integration.spec.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import Highstock from 'highcharts/highstock';
 import {
   Chart,

--- a/packages/react-jsx-highstock/test/components/Navigator/Navigator.spec.js
+++ b/packages/react-jsx-highstock/test/components/Navigator/Navigator.spec.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 
 jest.mock('react-jsx-highcharts', () => ({
   ...jest.requireActual('react-jsx-highcharts'),

--- a/packages/react-jsx-highstock/test/components/Navigator/NavigatorXAxis.integration.spec.js
+++ b/packages/react-jsx-highstock/test/components/Navigator/NavigatorXAxis.integration.spec.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import Highstock from 'highcharts/highstock';
 import {
   Chart,

--- a/packages/react-jsx-highstock/test/components/RangeSelector/RangeSelector.spec.js
+++ b/packages/react-jsx-highstock/test/components/RangeSelector/RangeSelector.spec.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import {
   Highcharts,
   createMockProvidedChart,

--- a/packages/react-jsx-highstock/test/components/Scrollbar/Scrollbar.spec.js
+++ b/packages/react-jsx-highstock/test/components/Scrollbar/Scrollbar.spec.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { createMockProvidedChart } from '../../test-utils';
 
 jest.mock('react-jsx-highcharts', () => ({


### PR DESCRIPTION
Apparently the way forward with importing react is by:
```javascript
import * as React from 'react';
```
For reference: https://github.com/facebook/react/pull/18102

I find the syntax a little odd, but apparently it makes better webpack builds also:
https://twitter.com/sebmarkbage/status/1250284377138802689

In the future, the import can be dropped altogether, but I guess that at least the peerDependency of react needs to be bumped. Which means major release.

This PR is just to be forward compatible. No breaking changes here.