### PR TITLE
Return the map chart instance to the callback prop

### DIFF
--- a/packages/react-jsx-highmaps/src/components/HighchartsMapChart/HighchartsMapChart.js
+++ b/packages/react-jsx-highmaps/src/components/HighchartsMapChart/HighchartsMapChart.js
@@ -25,7 +25,7 @@ const HighchartsMapChart = ({ map, chart, callback, ...restProps }) => {
         cbChart.mapCreditsFull = format(mapTextFull, { geojson });
       }
 
-      if (callback) callback(chart);
+      if (callback) callback(cbChart);
     },
     [callback]
   );

--- a/packages/react-jsx-highmaps/test/components/HighchartsMapChart/HighchartsMapChart.spec.js
+++ b/packages/react-jsx-highmaps/test/components/HighchartsMapChart/HighchartsMapChart.spec.js
@@ -59,4 +59,11 @@ describe('<HighchartsMapChart />', () => {
     const wrapper = mount(<HighchartsMapChart plotOptions={{ c: 'd' }} />);
     expect(wrapper.find(BaseChart)).toHaveProp('plotOptions', { c: 'd' });
   });
+
+  it('return a chart instance to the callback prop', () => {
+    let chart;
+    const chartCallback = (returnedChart) => chart = returnedChart;
+    mount(<HighchartsMapChart callback={chartCallback} />);
+    expect(chart).toBeDefined();
+  })
 });


### PR DESCRIPTION
It looks like the chart that was being returned in the callback prop is the chart that is passed as a prop (thus `undefined` if no chart is passed). This pull request changes the instance returned in the callback and adds a test to ensure that the chart return is defined.