### PR TITLE
Do not call chart.setSize when both height and width are undefined

### DIFF
--- a/packages/react-jsx-highcharts/src/components/Chart/Chart.js
+++ b/packages/react-jsx-highcharts/src/components/Chart/Chart.js
@@ -12,7 +12,7 @@ const Chart = memo(({ type = 'line', width, height, ...restProps }) => {
   const modifiedProps = useModifiedProps({ type, ...restProps });
 
   useEffect(() => {
-    if (!(typeof width === 'undefined' && typeof height === 'undefined')) {
+    if (!(width === undefined && height === undefined)) {
       chart.setSize(width, height);
     }
   }, [width, height]);

--- a/packages/react-jsx-highcharts/src/components/Chart/Chart.js
+++ b/packages/react-jsx-highcharts/src/components/Chart/Chart.js
@@ -5,31 +5,30 @@ import useModifiedProps from '../UseModifiedProps';
 import useChart from '../UseChart';
 import useManualEventHandlers from '../UseManualEventHandlers';
 
-const Chart = memo(({ type = 'line', ...restProps }) => {
+const Chart = memo(({ type = 'line', width, height, ...restProps }) => {
   const chart = useChart();
   const mounted = useRef(false);
 
   const modifiedProps = useModifiedProps({ type, ...restProps });
 
   useEffect(() => {
+    if (!(typeof width === 'undefined' && typeof height === 'undefined')) {
+      chart.setSize(width, height);
+    }
+  }, [width, height]);
+
+  useEffect(() => {
     if (modifiedProps !== false && mounted.current) {
-      const { width, height, ...restModified } = modifiedProps;
-      if (width || height) {
-        chart.setSize(restProps.width, restProps.height);
-      }
-      const notEventProps = getNonEventHandlerProps(restModified);
+      const notEventProps = getNonEventHandlerProps(modifiedProps);
       if (Object.getOwnPropertyNames(notEventProps).length > 0) {
-        updateChart(restModified, chart, chart.needsRedraw);
+        updateChart(modifiedProps, chart, chart.needsRedraw);
       }
     }
   });
 
   useEffect(() => {
-    const { width, height, ...rest } = restProps;
+    const notEventProps = getNonEventHandlerProps({ type, ...restProps });
 
-    const notEventProps = getNonEventHandlerProps({ type, ...rest });
-
-    chart.setSize(width, height);
     updateChart(notEventProps, chart);
     mounted.current = true;
   }, []);

--- a/packages/react-jsx-highcharts/test/components/Chart/Chart.spec.js
+++ b/packages/react-jsx-highcharts/test/components/Chart/Chart.spec.js
@@ -153,5 +153,11 @@ describe('<Chart />', () => {
       wrapper.setProps({ width: 600, height: 400 });
       expect(testContext.chartStubs.setSize).toHaveBeenCalledWith(600, 400);
     });
+
+    it('does not update size if both width and height are undefined', () => {
+      const wrapper = mount(<ProvidedChart />);
+
+      expect(testContext.chartStubs.setSize).not.toHaveBeenCalled();
+    });
   });
 });


### PR DESCRIPTION
This is a workaround for #299.

Also this now allows height and width to be set 0 or null.