### PR TITLE
Update README to point to HighchartsProvider instead of withHighcharts

### DIFF
--- a/packages/react-jsx-highcharts/README.md
+++ b/packages/react-jsx-highcharts/README.md
@@ -109,8 +109,8 @@ title: {
 ## Example
 
 ```jsx
-render () {
-  return (
+const MyChart = (props) => (
+  <HighchartsProvider Highcharts={Highcharts}>
     <HighchartsChart>
       <Chart />
 
@@ -133,11 +133,8 @@ render () {
         <LineSeries name="Other" data={[12908, 5948, 8105, 11248, 8989, 11816, 18274, 18111]} />
       </YAxis>
     </HighchartsChart>
-  );
-}
-
-// Provide Highcharts object for library to interact with
-export default withHighcharts(MyComponent, Highcharts);
+  </HighchartsProvider>
+)
 ```
 
 ## Demos
@@ -185,7 +182,7 @@ In the vast majority of cases, there is no need to use these Hooks directly - bu
 
 **Uncaught TypeError: Cannot read property 'chart' of undefined**
 
-You need to use the `withHighcharts` higher order component to inject the Highcharts object. [See here](https://github.com/whawker/react-jsx-highcharts/wiki/Higher-Order-Components#withhighcharts-version-200)
+You need to provide Highcharts for the components with ```<HighchartsProvider Highcharts={Highcharts}>```.
 
 **Uncaught TypeError: Cannot read property 'stockChart' of undefined**
 

--- a/packages/react-jsx-highmaps/README.md
+++ b/packages/react-jsx-highmaps/README.md
@@ -102,8 +102,8 @@ title: {
 // import Highmaps from 'highcharts/highmaps' - Import Highmaps from Highcharts
 // import { Fetch } from 'react-request'
 
-render () {
-  return (
+const MyMapChart = (props) => (
+  <HighmapsProvider Highcharts={Highmaps}>
     <Fetch url="https://code.highcharts.com/mapdata/custom/europe.geo.json">
       {({ fetching, failed, data }) => {
         if (fetching) return <div>Loading…</div>
@@ -144,11 +144,8 @@ render () {
         return null
       }}
     </Fetch>
-  );
-}
-
-// Provide Highmaps object for library to interact with
-export default withHighmaps(MyComponent, Highmaps);
+  </HighmapsProvider>
+);
 ```
 
 ## More info

--- a/packages/react-jsx-highstock-datepickers/README.md
+++ b/packages/react-jsx-highstock-datepickers/README.md
@@ -1,4 +1,5 @@
 # react-jsx-highstock-datepickers
+*DEPRECATED*
 
 [React Day Pickers](http://react-day-picker.js.org/) for [React JSX Highstock](https://github.com/whawker/react-jsx-highcharts/tree/master/packages/react-jsx-highstock#readme) as a drop in replacement for the default Highstock `rangeSelector.input` field.
 

--- a/packages/react-jsx-highstock/README.md
+++ b/packages/react-jsx-highstock/README.md
@@ -117,8 +117,8 @@ title: {
 ```jsx
 // import Highcharts from 'highcharts/highstock' - Import Highstock from Highcharts
 
-render () {
-  return (
+const MyChart = (props) => (
+  <HighchartsProvider Highcharts={Highcharts}>
     <HighchartsStockChart>
       <Chart onClick={this.handleClick} zoomType="x" />
 
@@ -157,11 +157,8 @@ render () {
         <Navigator.Series seriesId="twitter" />
       </Navigator>
     </HighchartsStockChart>
-  );
-}
-
-// Provide Highcharts (Highstock) object for library to interact with
-export default withHighcharts(MyComponent, Highcharts);
+  </HighchartsProvider>
+);
 ```
 
 ## Demos


### PR DESCRIPTION
This removes mentions of withHighcharts in the READMEs. Also adds "DEPRECATED" to react-jsx-highstock-datepickers.

I think the react-jsx-highstock-datepickers should also be deprecated in npm registry with:
```sh
npm deprecate react-jsx-highstock-datepickers "<message>"
```
https://docs.npmjs.com/deprecating-and-undeprecating-packages-or-package-versions