### PR TITLE
Move rangeselector after xaxis in readme

### DIFF
--- a/packages/react-jsx-highstock/README.md
+++ b/packages/react-jsx-highstock/README.md
@@ -128,14 +128,6 @@ const MyChart = (props) => (
         <Legend.Title>Key</Legend.Title>
       </Legend>
 
-      <RangeSelector>
-        <RangeSelector.Button count={1} type="day">1d</RangeSelector.Button>
-        <RangeSelector.Button count={7} type="day">7d</RangeSelector.Button>
-        <RangeSelector.Button count={1} type="month">1m</RangeSelector.Button>
-        <RangeSelector.Button type="all">All</RangeSelector.Button>
-        <RangeSelector.Input boxBorderColor="#7cb5ec" />
-      </RangeSelector>
-
       <Tooltip />
 
       <XAxis>
@@ -151,6 +143,14 @@ const MyChart = (props) => (
         <YAxis.Title>Social Buzz</YAxis.Title>
         <SplineSeries id="twitter" name="Twitter mentions" data={data2} />
       </YAxis>
+
+      <RangeSelector>
+        <RangeSelector.Button count={1} type="day">1d</RangeSelector.Button>
+        <RangeSelector.Button count={7} type="day">7d</RangeSelector.Button>
+        <RangeSelector.Button count={1} type="month">1m</RangeSelector.Button>
+        <RangeSelector.Button type="all">All</RangeSelector.Button>
+        <RangeSelector.Input boxBorderColor="#7cb5ec" />
+      </RangeSelector>
 
       <Navigator>
         <Navigator.Series seriesId="profit" />


### PR DESCRIPTION
Fix rangeselector example in react-jsx-highstock readme.

Closes #305