### PR TITLE
Fix effect cleanups for react 17

### DIFF
--- a/packages/react-jsx-highcharts/src/components/Axis/Axis.js
+++ b/packages/react-jsx-highcharts/src/components/Axis/Axis.js
@@ -17,13 +17,13 @@ const Axis = ({ children = null, dynamicAxis = true, ...restProps }) => {
   const [hasAxis, setHasAxis] = useState(false);
 
   useEffect(() => {
-    axisRef.current = createAxis(chart, restProps, dynamicAxis);
+    const axis = createAxis(chart, restProps, dynamicAxis);
+    axisRef.current = axis;
     providedAxisRef.current = createProvidedAxis(axisRef.current);
     setHasAxis(true);
     chart.needsRedraw();
 
     return () => {
-      const axis = axisRef.current;
       if (axis.remove && dynamicAxis) {
         // Axis may have already been removed, i.e. when Chart unmounted
         attempt(axis.remove.bind(axis), false);

--- a/packages/react-jsx-highcharts/src/components/BaseChart/BaseChart.js
+++ b/packages/react-jsx-highcharts/src/components/BaseChart/BaseChart.js
@@ -33,8 +33,8 @@ const BaseChart = ({
   }, []);
 
   useEffect(() => {
+    const myChart = chartRef.current;
     return () => {
-      const myChart = chartRef.current;
       if (myChart) {
         // Fixes #14
         window.requestAnimationFrame(myChart.destroy.bind(myChart));

--- a/packages/react-jsx-highcharts/src/components/ColorAxis/ColorAxis.js
+++ b/packages/react-jsx-highcharts/src/components/ColorAxis/ColorAxis.js
@@ -15,7 +15,8 @@ const ColorAxis = ({ children = null, ...restProps }) => {
   const [hasColorAxis, setHasColorAxis] = useState(false);
 
   useEffect(() => {
-    colorAxisRef.current = createColorAxis(chart, restProps);
+    const colorAxis = createColorAxis(chart, restProps);
+    colorAxisRef.current = colorAxis;
     providedColorAxisRef.current = createProvidedColorAxis(
       colorAxisRef.current
     );
@@ -23,7 +24,6 @@ const ColorAxis = ({ children = null, ...restProps }) => {
     chart.needsRedraw();
 
     return () => {
-      const colorAxis = colorAxisRef.current;
       if (colorAxis && colorAxis.remove) {
         // Axis may have already been removed, i.e. when Chart unmounted
         attempt(colorAxis.remove.bind(colorAxis), false);

--- a/packages/react-jsx-highcharts/src/components/Series/Series.js
+++ b/packages/react-jsx-highcharts/src/components/Series/Series.js
@@ -55,14 +55,13 @@ const Series = memo(
     useEffect(() => {
       if (requiresAxis && !axis) return;
       const opts = getSeriesConfig(seriesProps, axis, colorAxis, requiresAxis);
-
-      seriesRef.current = addSeries(opts, false);
+      const series = addSeries(opts, false);
+      seriesRef.current = series;
       providerValueRef.current = createProvidedSeries(seriesRef.current);
 
       setHasSeries(true);
       needsRedraw();
       return () => {
-        const series = seriesRef.current;
         if (series && series.remove) {
           // Series may have already been removed, i.e. when Axis unmounted
           attempt(series.remove.bind(series), false);


### PR DESCRIPTION
### what?
[In React 17 the effect cleanup functions run asynchronously.](https://reactjs.org/blog/2020/08/10/react-v17-rc.html#effect-cleanup-timing).

This PR changes the cleanup functions so, that they should work in React 17 too.

### why?

React 17 should release this week.