### PR TITLE
Allow series eventhandlers to be updated

### DIFF
--- a/packages/react-jsx-highcharts/package-lock.json
+++ b/packages/react-jsx-highcharts/package-lock.json
@@ -1128,6 +1128,16 @@
         "regenerator-runtime": "^0.13.4"
       }
     },
+    "@babel/runtime-corejs3": {
+      "version": "7.12.5",
+      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.12.5.tgz",
+      "integrity": "sha512-roGr54CsTmNPPzZoCP1AmDXuBoNao7tnSA83TXTwt+UK5QVyh1DIJnrgYRPWKCF2flqZQXwa7Yr8v7VmLzF0YQ==",
+      "dev": true,
+      "requires": {
+        "core-js-pure": "^3.0.0",
+        "regenerator-runtime": "^0.13.4"
+      }
+    },
     "@babel/template": {
       "version": "7.12.7",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.12.7.tgz",
@@ -1872,6 +1882,89 @@
         "@sinonjs/commons": "^1.7.0"
       }
     },
+    "@testing-library/dom": {
+      "version": "7.28.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-7.28.1.tgz",
+      "integrity": "sha512-acv3l6kDwZkQif/YqJjstT3ks5aaI33uxGNVIQmdKzbZ2eMKgg3EV2tB84GDdc72k3Kjhl6mO8yUt6StVIdRDg==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^4.2.0",
+        "aria-query": "^4.2.2",
+        "chalk": "^4.1.0",
+        "dom-accessibility-api": "^0.5.4",
+        "lz-string": "^1.4.4",
+        "pretty-format": "^26.6.2"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+          "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
+    "@testing-library/react": {
+      "version": "11.2.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-11.2.2.tgz",
+      "integrity": "sha512-jaxm0hwUjv+hzC+UFEywic7buDC9JQ1q3cDsrWVSDAPmLotfA6E6kUHlYm/zOeGCac6g48DR36tFHxl7Zb+N5A==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.12.5",
+        "@testing-library/dom": "^7.28.1"
+      }
+    },
+    "@types/aria-query": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-4.2.0.tgz",
+      "integrity": "sha512-iIgQNzCm0v7QMhhe4Jjn9uRh+I6GoPmt03CbEtwx3ao8/EfoQcmgtqH4vQ5Db/lxiIGaWDv6nwvunuh0RyX0+A==",
+      "dev": true
+    },
     "@types/babel__core": {
       "version": "7.1.12",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.12.tgz",
@@ -2368,6 +2461,16 @@
       "dev": true,
       "requires": {
         "sprintf-js": "~1.0.2"
+      }
+    },
+    "aria-query": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-4.2.2.tgz",
+      "integrity": "sha512-o/HelwhuKpTj/frsOsbNLNgnNGVIFsVP/SW2BSF14gVl7kAfMOJ6/8wUAUvG1R1NHKrfG+2sHZTu0yauT1qBrA==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.10.2",
+        "@babel/runtime-corejs3": "^7.10.2"
       }
     },
     "arr-diff": {
@@ -3645,6 +3748,12 @@
         }
       }
     },
+    "core-js-pure": {
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.8.1.tgz",
+      "integrity": "sha512-Se+LaxqXlVXGvmexKGPvnUIYC1jwXu1H6Pkyb3uBM5d8/NELMYCHs/4/roD7721NxrTLyv7e5nXd5/QLBO+10g==",
+      "dev": true
+    },
     "core-util-is": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
@@ -3985,6 +4094,12 @@
       "requires": {
         "esutils": "^2.0.2"
       }
+    },
+    "dom-accessibility-api": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.4.tgz",
+      "integrity": "sha512-TvrjBckDy2c6v6RLxPv5QXOnU+SmF9nBII5621Ve5fu6Z/BDrENurBEvlC1f44lKEUVqOpK4w9E5Idc5/EgkLQ==",
+      "dev": true
     },
     "dom-serializer": {
       "version": "0.1.1",
@@ -8575,6 +8690,12 @@
       "requires": {
         "yallist": "^4.0.0"
       }
+    },
+    "lz-string": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.4.4.tgz",
+      "integrity": "sha1-wNjq82BZ9wV5bh40SBHPTEmNOiY=",
+      "dev": true
     },
     "make-dir": {
       "version": "2.1.0",

--- a/packages/react-jsx-highcharts/package.json
+++ b/packages/react-jsx-highcharts/package.json
@@ -68,6 +68,7 @@
     "@babel/plugin-transform-runtime": "^7.12.1",
     "@babel/preset-env": "^7.12.7",
     "@babel/preset-react": "^7.12.7",
+    "@testing-library/react": "^11.2.2",
     "@types/react": "^16.14.2",
     "babel-eslint": "^10.1.0",
     "babel-loader": "^8.2.2",

--- a/packages/react-jsx-highcharts/test/ContextSpy.js
+++ b/packages/react-jsx-highcharts/test/ContextSpy.js
@@ -1,10 +1,17 @@
 import { useEffect } from 'react';
-import { useAxis, useChart, useHighcharts } from '../src';
+import { useAxis, useChart, useHighcharts, useSeries } from '../src';
 
-const ContextSpy = ({ axisId, axisRef, chartRef, highchartsRef }) => {
+const ContextSpy = ({
+  axisId,
+  axisRef,
+  chartRef,
+  highchartsRef,
+  seriesRef
+}) => {
   const axis = useAxis(axisId);
   const chart = useChart();
   const Highcharts = useHighcharts();
+  const series = useSeries();
 
   useEffect(() => {
     if (highchartsRef) {
@@ -48,6 +55,18 @@ const ContextSpy = ({ axisId, axisRef, chartRef, highchartsRef }) => {
       }
     };
   }, [axis]);
+
+  useEffect(() => {
+    if (seriesRef) {
+      seriesRef.current = series;
+    }
+
+    return () => {
+      if (seriesRef) {
+        seriesRef.current = null;
+      }
+    };
+  }, [series]);
 
   return null;
 };

--- a/packages/react-jsx-highcharts/test/components/Series/Series.integration.spec.js
+++ b/packages/react-jsx-highcharts/test/components/Series/Series.integration.spec.js
@@ -1,0 +1,59 @@
+import * as React from 'react';
+import Highcharts from 'highcharts';
+import { render, waitFor } from '@testing-library/react';
+
+import {
+  HighchartsChart,
+  Chart,
+  YAxis,
+  XAxis,
+  HighchartsProvider,
+  Series
+} from '../../../src';
+
+import ContextSpy from '../../ContextSpy';
+
+describe('<Series /> integration', () => {
+  let Component;
+  let seriesRef;
+  beforeEach(() => {
+    seriesRef = {};
+
+    Component = props => {
+      return (
+        <HighchartsProvider Highcharts={Highcharts}>
+          <HighchartsChart>
+            <Chart zoomType="x" />
+            <XAxis></XAxis>
+            <YAxis>
+              <Series type="line" data={[1, 2, 3, 4]} {...props}>
+                <ContextSpy seriesRef={seriesRef} />
+              </Series>
+            </YAxis>
+          </HighchartsChart>
+        </HighchartsProvider>
+      );
+    };
+  });
+
+  it('fires onHide eventhandler', () => {
+    const onHide = jest.fn();
+
+    const wrapper = render(<Component onHide={onHide} />);
+    seriesRef.current.object.hide();
+    expect(onHide).toHaveBeenCalled();
+  });
+
+  it('changes onHide eventhandler when new one is passed', () => {
+    const onHide1 = jest.fn();
+    const onHide2 = jest.fn();
+
+    const wrapper = render(<Component onHide={onHide1} />);
+
+    wrapper.rerender(<Component onHide={onHide2} />);
+
+    seriesRef.current.object.hide();
+    expect(onHide1).not.toHaveBeenCalled();
+    expect(onHide2).toHaveBeenCalled();
+  });
+});

--- a/packages/react-jsx-highcharts/test/components/Series/Series.integration.spec.js
+++ b/packages/react-jsx-highcharts/test/components/Series/Series.integration.spec.js
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import Highcharts from 'highcharts';
-import { render, waitFor } from '@testing-library/react';
+import { render } from '@testing-library/react';
 
 import {
   HighchartsChart,

--- a/packages/react-jsx-highcharts/test/components/Series/SeriesTypes.integration.spec.js
+++ b/packages/react-jsx-highcharts/test/components/Series/SeriesTypes.integration.spec.js
@@ -23,6 +23,8 @@ import addVennModule from 'highcharts/modules/venn';
 import addWindBarbModule from 'highcharts/modules/windbarb';
 import addXRangeModule from 'highcharts/modules/xrange';
 
+import { render } from '@testing-library/react';
+
 import {
   HighchartsChart,
   Chart,
@@ -88,7 +90,7 @@ Object.keys(all)
             }
             done();
           };
-          const Component = props => {
+          const Component = () => {
             return (
               <HighchartsProvider Highcharts={Highcharts}>
                 <HighchartsChart>
@@ -100,7 +102,7 @@ Object.keys(all)
               </HighchartsProvider>
             );
           };
-          mount(<Component />);
+          render(<Component />);
         });
         it('binds hide event correctly', done => {
           const afterAddSeries = event => {
@@ -112,7 +114,7 @@ Object.keys(all)
             expect(event.target.visible).toBe(false);
             done();
           };
-          const Component = props => {
+          const Component = () => {
             return (
               <HighchartsProvider Highcharts={Highcharts}>
                 <HighchartsChart>
@@ -125,7 +127,7 @@ Object.keys(all)
               </HighchartsProvider>
             );
           };
-          mount(<Component />);
+          render(<Component />);
         });
       }
     });


### PR DESCRIPTION
This adds code to change series eventhandlers when they are changed in the props.

Somewhat related to #308.  If there are no problems with updating series eventhandlers, then it should not be too hard to use same mechanism in axis too.

I had to add dependency for react-testing-library as the tests were incredibly complex with enzyme. I am hoping we could migrate the other tests use react-testing-library as well.