### PR TITLE
Drop support for react 16 and highcharts 8

### DIFF
--- a/packages/react-jsx-highcharts/package.json
+++ b/packages/react-jsx-highcharts/package.json
@@ -97,9 +97,9 @@
     "uuid": "^8.3.2"
   },
   "peerDependencies": {
-    "highcharts": "^8.0.0 || ^9.0.0",
-    "react": "^16.8.6 || ^17.0.0",
-    "react-dom": "^16.8.6 || ^17.0.0",
+    "highcharts": "^9.1.1",
+    "react": "^17.0.2",
+    "react-dom": "^17.0.2",
     "prop-types": "^15.0.0"
   },
   "browserslist": [

--- a/packages/react-jsx-highmaps/package.json
+++ b/packages/react-jsx-highmaps/package.json
@@ -78,10 +78,10 @@
     "webpack-cli": "^4.7.2"
   },
   "peerDependencies": {
-    "highcharts": "^8.0.0 || ^9.0.0",
-    "prop-types": "^15.0.0",
-    "react": "^16.8.6 || ^17.0.0",
-    "react-dom": "^16.8.6 || ^17.0.0"
+    "highcharts": "^9.1.1",
+    "react": "^17.0.2",
+    "react-dom": "^17.0.2",
+    "prop-types": "^15.0.0"
   },
   "browserslist": [
     "ie >= 11"

--- a/packages/react-jsx-highstock/package.json
+++ b/packages/react-jsx-highstock/package.json
@@ -93,10 +93,10 @@
     "webpack-cli": "^4.7.2"
   },
   "peerDependencies": {
-    "highcharts": "^8.0.0 || ^9.0.0",
-    "prop-types": "^15.0.0",
-    "react": "^16.8.6 || ^17.0.0",
-    "react-dom": "^16.8.6 || ^17.0.0"
+    "highcharts": "^9.1.1",
+    "react": "^17.0.2",
+    "react-dom": "^17.0.2",
+    "prop-types": "^15.0.0"
   },
   "browserslist": [
     "ie >= 11"


### PR DESCRIPTION
### what?

Drop support for react < 17 and highcharts < 9.1.1.

### why?

#333 is probably a breaking change. If major version needs to be released, this just drops support for some old versions.

