### PR TITLE
Add typescript definitions for react-jsx-highstock

### DIFF
--- a/packages/react-jsx-highstock/package-lock.json
+++ b/packages/react-jsx-highstock/package-lock.json
@@ -2543,6 +2543,29 @@
       "integrity": "sha512-PijRCG/K3s3w1We6ynUKdxEc5AcuuH3NBmMDP8uvKVp6X43UY7NQlTzczakXP3DJR0F4dfNQIGjU2cUeRYs2AA==",
       "dev": true
     },
+    "@types/prop-types": {
+      "version": "15.7.3",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.3.tgz",
+      "integrity": "sha512-KfRL3PuHmqQLOG+2tGpRO26Ctg+Cq1E01D2DMriKEATHgWLfeNDmq9e29Q9WIky0dQ3NPkd1mzYH8Lm936Z9qw==",
+      "dev": true
+    },
+    "@types/react": {
+      "version": "17.0.11",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.11.tgz",
+      "integrity": "sha512-yFRQbD+whVonItSk7ZzP/L+gPTJVBkL/7shLEF+i9GC/1cV3JmUxEQz6+9ylhUpWSDuqo1N9qEvqS6vTj4USUA==",
+      "dev": true,
+      "requires": {
+        "@types/prop-types": "*",
+        "@types/scheduler": "*",
+        "csstype": "^3.0.2"
+      }
+    },
+    "@types/scheduler": {
+      "version": "0.16.1",
+      "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.1.tgz",
+      "integrity": "sha512-EaCxbanVeyxDRTQBkdLb3Bvl/HK7PBK6UJjsSixB0iHKoWxE5uu2Q/DgtpOhPIojN0Zl1whvOd7PoHs2P0s5eA==",
+      "dev": true
+    },
     "@types/stack-utils": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.0.tgz",
@@ -3833,6 +3856,12 @@
           "dev": true
         }
       }
+    },
+    "csstype": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.8.tgz",
+      "integrity": "sha512-jXKhWqXPmlUeoQnF/EhTtTl4C9SnrxSH/jZUih3jmO6lBKr99rP3/+FmrMj4EFpOXzMtXHAZkd3x0E6h6Fgflw==",
+      "dev": true
     },
     "data-urls": {
       "version": "2.0.0",
@@ -10450,6 +10479,12 @@
       "requires": {
         "is-typedarray": "^1.0.0"
       }
+    },
+    "typescript": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.3.2.tgz",
+      "integrity": "sha512-zZ4hShnmnoVnAHpVHWpTcxdv7dWP60S2FsydQLV8V5PbS3FifjWFFRiHSWpDJahly88PRyV5teTSLoq4eG7mKw==",
+      "dev": true
     },
     "unbox-primitive": {
       "version": "1.0.1",

--- a/packages/react-jsx-highstock/package.json
+++ b/packages/react-jsx-highstock/package.json
@@ -4,10 +4,12 @@
   "description": "Highcharts (including Highstock) charts built using React components",
   "main": "dist/react-jsx-highstock.min.js",
   "module": "dist/es/index.js",
+  "types": "types/index.d.ts",
   "sideEffects": false,
   "files": [
     "dist",
-    "src"
+    "src",
+    "types"
   ],
   "scripts": {
     "build": "cross-env NODE_ENV=development ./node_modules/.bin/webpack",
@@ -18,7 +20,8 @@
     "format": "prettier --write \"src/**/*.js\" \"test/**/*.js\" README.md",
     "lint": "eslint src",
     "test": "jest",
-    "test:coverage": "jest --coverage"
+    "test:coverage": "jest --coverage",
+    "test:types": "tsc --noEmit"
   },
   "author": "Will Hawker",
   "contributors": [
@@ -70,6 +73,7 @@
     "@babel/preset-env": "^7.14.5",
     "@babel/preset-react": "^7.14.5",
     "@testing-library/react": "^11.2.7",
+    "@types/react": "^17.0.11",
     "babel-eslint": "^10.1.0",
     "babel-loader": "^8.2.2",
     "babel-plugin-transform-react-remove-prop-types": "^0.4.24",
@@ -89,6 +93,7 @@
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "rimraf": "^3.0.2",
+    "typescript": "^4.3.2",
     "webpack": "^5.38.1",
     "webpack-cli": "^4.7.2"
   },

--- a/packages/react-jsx-highstock/tsconfig.json
+++ b/packages/react-jsx-highstock/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "compilerOptions": {
+    "moduleResolution": "node",
+    "noImplicitAny": true,
+    "target": "ES2020"
+  },
+  "include": ["./types/**/*"]
+}

--- a/packages/react-jsx-highstock/types/index.d.ts
+++ b/packages/react-jsx-highstock/types/index.d.ts
@@ -1,0 +1,71 @@
+import type * as Highcharts from 'highcharts';
+import type { ReactElement, ReactNode } from 'react';
+import { HighchartsChartProps, SeriesProps } from 'react-jsx-highcharts';
+
+export * from 'react-jsx-highcharts';
+
+export function HighchartsStockChart(props: HighchartsChartProps): ReactElement;
+
+// Navigator
+type NavigatorProps = {
+  children?: ReactNode;
+} & Partial<Highcharts.NavigatorOptions>;
+export function Navigator(props: NavigatorProps): ReactElement;
+export namespace Navigator {
+  type NavigatorSeriesProps = {
+    seriesId: string
+  }
+  export function Series(props: NavigatorSeriesProps): ReactElement;
+
+  type NavigatorXAxisProps = {
+    children?: ReactNode
+  } & Partial<Highcharts.NavigatorXAxisOptions>;
+  export function XAxis(props: NavigatorXAxisProps): ReactElement;
+
+  type NavigatorYAxisProps = {
+    children?: ReactNode
+  } & Partial<Highcharts.NavigatorYAxisOptions>;
+  export function YAxis(props: NavigatorYAxisProps): ReactElement;
+}
+
+// RangeSelector
+type RangeSelectorProps = {
+  children?: ReactNode;
+} & Partial<Highcharts.RangeSelectorOptions>;
+export function RangeSelector(
+  props: RangeSelectorProps
+): ReactElement;
+export namespace RangeSelector {
+  type RangeSelectorButtonProps = {
+    children?: ReactNode;
+  } & Partial<Omit<Highcharts.RangeSelectorButtonsOptions, "text">>;
+  export function Button(props: RangeSelectorButtonProps): ReactElement;
+
+  type RangeSelectorInputProps = {
+    boxBorderColor?: Highcharts.ColorString;
+    boxHeight?: number;
+    boxWidth?: (number|undefined);
+    dateFormat?: string;
+    dateParser?: Highcharts.RangeSelectorParseCallbackFunction;
+    editDateFormat?: string;
+    enabled?: boolean;
+    position?: Highcharts.RangeSelectorInputPositionOptions;
+    spacing?: number;
+    style?: Highcharts.CSSObject;
+  }
+  export function Input(props: RangeSelectorInputProps): ReactElement;
+}
+
+// Scrollbar
+export function Scrollbar(props: Highcharts.ScrollbarOptions): ReactElement;
+
+// Series
+export function CandlestickSeries(
+  props: SeriesProps<Highcharts.SeriesCandlestickOptions>
+): ReactElement;
+export function FlagsSeries(
+  props: SeriesProps<Highcharts.SeriesFlagsOptions>
+): ReactElement;
+export function OHLCSeries(
+  props: SeriesProps<Highcharts.SeriesOhlcOptions>
+): ReactElement;


### PR DESCRIPTION
This builds on #303 and extends types to also cover the
react-jsx-highstock package.

Please verify that the type definitions makes sense, @anajavi and and
@whawker. I used the types you defined, @anajavi, as reference and tried
to compare props of RJH components with Highcharts config types.

It works for our usage of RJH, but not all components are tested.