### PR TITLE
Use cross-env in build:es script

### DIFF
--- a/packages/react-jsx-highcharts/package.json
+++ b/packages/react-jsx-highcharts/package.json
@@ -12,10 +12,10 @@
     "types"
   ],
   "scripts": {
-    "build": "cross-env NODE_ENV=development ./node_modules/.bin/webpack",
+    "build": "cross-env NODE_ENV=development webpack",
     "build:prod": "npm run build:umd && npm run build:es",
-    "build:umd": "cross-env NODE_ENV=production ./node_modules/.bin/webpack",
-    "build:es": "BABEL_ENV=es babel src --out-dir dist/es",
+    "build:umd": "cross-env NODE_ENV=production webpack",
+    "build:es": "cross-env BABEL_ENV=es babel src --out-dir dist/es",
     "clean": "rimraf dist",
     "format": "prettier --write \"src/**/*.js\" \"test/**/*.js\" README.md \"../../README.md\"",
     "lint": "eslint src",

--- a/packages/react-jsx-highstock/package.json
+++ b/packages/react-jsx-highstock/package.json
@@ -10,10 +10,10 @@
     "src"
   ],
   "scripts": {
-    "build": "cross-env NODE_ENV=development ./node_modules/.bin/webpack",
+    "build": "cross-env NODE_ENV=development webpack",
     "build:prod": "npm run build:umd && npm run build:es",
-    "build:umd": "cross-env NODE_ENV=production ./node_modules/.bin/webpack",
-    "build:es": "BABEL_ENV=es babel src --out-dir dist/es",
+    "build:umd": "cross-env NODE_ENV=production webpack",
+    "build:es": "cross-env BABEL_ENV=es babel src --out-dir dist/es",
     "clean": "rimraf dist",
     "format": "prettier --write \"src/**/*.js\" \"test/**/*.js\" README.md",
     "lint": "eslint src",


### PR DESCRIPTION
It's needed when building on Windows.

Also removing full path to webpack binary as npm figures that out on
itself.