### PR TITLE
Drop lodash dependency from react-jsx-highmaps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10246,32 +10246,13 @@
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.15.4",
-        "lodash-es": "^4.17.21",
         "react-jsx-highcharts": "4.3.1"
-      },
-      "devDependencies": {
-        "lodash-webpack-plugin": "^0.11.6"
       },
       "peerDependencies": {
         "highcharts": "^8.0.0 || ^9.0.0",
         "prop-types": "^15.0.0",
         "react": "^16.8.6 || ^17.0.0",
         "react-dom": "^16.8.6 || ^17.0.0"
-      }
-    },
-    "packages/react-jsx-highmaps/node_modules/lodash-es": {
-      "version": "4.17.21",
-      "license": "MIT"
-    },
-    "packages/react-jsx-highmaps/node_modules/lodash-webpack-plugin": {
-      "version": "0.11.6",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "lodash": "^4.17.20"
-      },
-      "peerDependencies": {
-        "webpack": "^2.0.0 || ^3.0.0 || ^4.0.0 || ^5.1.0"
       }
     },
     "packages/react-jsx-highstock": {
@@ -16756,21 +16737,7 @@
       "version": "file:packages/react-jsx-highmaps",
       "requires": {
         "@babel/runtime": "^7.15.4",
-        "lodash-es": "^4.17.21",
-        "lodash-webpack-plugin": "^0.11.6",
         "react-jsx-highcharts": "4.3.1"
-      },
-      "dependencies": {
-        "lodash-es": {
-          "version": "4.17.21"
-        },
-        "lodash-webpack-plugin": {
-          "version": "0.11.6",
-          "dev": true,
-          "requires": {
-            "lodash": "^4.17.20"
-          }
-        }
       }
     },
     "react-jsx-highstock": {

--- a/packages/react-jsx-highmaps/jest.config.js
+++ b/packages/react-jsx-highmaps/jest.config.js
@@ -6,8 +6,7 @@
 const config = {
   testEnvironment: 'jsdom',
   setupFilesAfterEnv: ['<rootDir>/test/test-helper.js'],
-  testMatch: ['**/test/**/*.spec.js?(x)'],
-  transformIgnorePatterns: ['node_modules/(?!(lodash-es)/)']
+  testMatch: ['**/test/**/*.spec.js?(x)']
 };
 
 module.exports = config;

--- a/packages/react-jsx-highmaps/package.json
+++ b/packages/react-jsx-highmaps/package.json
@@ -46,11 +46,7 @@
   ],
   "dependencies": {
     "@babel/runtime": "^7.15.4",
-    "lodash-es": "^4.17.21",
     "react-jsx-highcharts": "4.3.1"
-  },
-  "devDependencies": {
-    "lodash-webpack-plugin": "^0.11.6"
   },
   "peerDependencies": {
     "highcharts": "^8.0.0 || ^9.0.0",

--- a/packages/react-jsx-highmaps/src/components/MapNavigation/MapNavigationButton.js
+++ b/packages/react-jsx-highmaps/src/components/MapNavigation/MapNavigationButton.js
@@ -1,6 +1,5 @@
 import { useEffect } from 'react';
 import PropTypes from 'prop-types';
-import { isEmpty } from 'lodash-es';
 import { useHighcharts, useChart } from 'react-jsx-highcharts';
 
 const MapNavigationButton = props => {
@@ -34,9 +33,11 @@ const getMapNavigationButtonConfig = (props, Highcharts) => {
 };
 
 const updateMapNavigationButton = (type, config, chart) => {
+  const enableButtons = Object.keys(config).length > 0;
+
   chart.update({
     mapNavigation: {
-      enableButtons: !isEmpty(config),
+      enableButtons,
       buttons: {
         [type]: config
       }

--- a/packages/react-jsx-highmaps/webpack.config.js
+++ b/packages/react-jsx-highmaps/webpack.config.js
@@ -1,6 +1,5 @@
 /* eslint-env node */
 const path = require('path');
-const LodashModuleReplacementPlugin = require('lodash-webpack-plugin');
 
 const isProd = process.env.NODE_ENV === 'production';
 
@@ -48,13 +47,7 @@ const webpackConfig = {
         exclude: /node_modules(\\|\/)(?!react-jsx-highcharts)/
       }
     ]
-  },
-
-  plugins: [
-    new LodashModuleReplacementPlugin({
-      collections: true
-    })
-  ]
+  }
 };
 
 if (isProd) {


### PR DESCRIPTION
Remove last use of lodash in react-jsx-highmaps.

It was surprisingly simple fix.