### PR TITLE
Support highcharts v10

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
         "eslint-plugin-react": "^7.27.1",
         "eslint-plugin-react-hooks": "^4.3.0",
         "eslint-plugin-react-perf": "^3.3.1",
-        "highcharts": "^9.3.0",
+        "highcharts": "^10.0.0",
         "jest": "^27.3.1",
         "prettier": "^2.4.1",
         "prop-types": "^15.7.2",
@@ -5468,9 +5468,9 @@
       }
     },
     "node_modules/highcharts": {
-      "version": "9.3.0",
-      "resolved": "https://registry.npmjs.org/highcharts/-/highcharts-9.3.0.tgz",
-      "integrity": "sha512-nQ7yW5ni7wFiPgDN2IWrS6o6NjL1gK/OhZjrdpyB3FQuefMkTQngygP+JqZFMx7PDrP3YAvfejx0M5IgkC01ow=="
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/highcharts/-/highcharts-10.0.0.tgz",
+      "integrity": "sha512-a14PrTraVaoSNyaRPhLF/jJ3/09rJwfUZedLgZOkzozGz4K/H8WtWNJtUZt/tc5QiJkaZHw4YX7vvuO98s+EoA=="
     },
     "node_modules/html-encoding-sniffer": {
       "version": "2.0.1",
@@ -10175,7 +10175,7 @@
         "uuid": "^8.3.2"
       },
       "peerDependencies": {
-        "highcharts": "^8.0.0 || ^9.0.0",
+        "highcharts": "^8.0.0 || ^9.0.0 || 10.0.0",
         "prop-types": "^15.0.0",
         "react": "^16.8.6 || ^17.0.0",
         "react-dom": "^16.8.6 || ^17.0.0"
@@ -10196,7 +10196,7 @@
         "react-jsx-highcharts": "4.3.1"
       },
       "peerDependencies": {
-        "highcharts": "^8.0.0 || ^9.0.0",
+        "highcharts": "^8.0.0 || ^9.0.0 || 10.0.0",
         "prop-types": "^15.0.0",
         "react": "^16.8.6 || ^17.0.0",
         "react-dom": "^16.8.6 || ^17.0.0"
@@ -10210,7 +10210,7 @@
         "react-jsx-highcharts": "4.3.1"
       },
       "peerDependencies": {
-        "highcharts": "^8.0.0 || ^9.0.0",
+        "highcharts": "^8.0.0 || ^9.0.0 || 10.0.0",
         "prop-types": "^15.0.0",
         "react": "^16.8.6 || ^17.0.0",
         "react-dom": "^16.8.6 || ^17.0.0"
@@ -14271,9 +14271,9 @@
       }
     },
     "highcharts": {
-      "version": "9.3.0",
-      "resolved": "https://registry.npmjs.org/highcharts/-/highcharts-9.3.0.tgz",
-      "integrity": "sha512-nQ7yW5ni7wFiPgDN2IWrS6o6NjL1gK/OhZjrdpyB3FQuefMkTQngygP+JqZFMx7PDrP3YAvfejx0M5IgkC01ow=="
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/highcharts/-/highcharts-10.0.0.tgz",
+      "integrity": "sha512-a14PrTraVaoSNyaRPhLF/jJ3/09rJwfUZedLgZOkzozGz4K/H8WtWNJtUZt/tc5QiJkaZHw4YX7vvuO98s+EoA=="
     },
     "html-encoding-sniffer": {
       "version": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "eslint-plugin-react": "^7.27.1",
     "eslint-plugin-react-hooks": "^4.3.0",
     "eslint-plugin-react-perf": "^3.3.1",
-    "highcharts": "^9.3.0",
+    "highcharts": "^10.0.0",
     "jest": "^27.3.1",
     "prettier": "^2.4.1",
     "prop-types": "^15.7.2",

--- a/packages/react-jsx-highcharts/package.json
+++ b/packages/react-jsx-highcharts/package.json
@@ -66,7 +66,7 @@
     "uuid": "^8.3.2"
   },
   "peerDependencies": {
-    "highcharts": "^8.0.0 || ^9.0.0",
+    "highcharts": "^8.0.0 || ^9.0.0 || ^10.0.0",
     "react": "^16.8.6 || ^17.0.0",
     "react-dom": "^16.8.6 || ^17.0.0",
     "prop-types": "^15.0.0"

--- a/packages/react-jsx-highmaps/package.json
+++ b/packages/react-jsx-highmaps/package.json
@@ -49,7 +49,7 @@
     "react-jsx-highcharts": "4.3.1"
   },
   "peerDependencies": {
-    "highcharts": "^8.0.0 || ^9.0.0",
+    "highcharts": "^8.0.0 || ^9.0.0 || ^10.0.0",
     "prop-types": "^15.0.0",
     "react": "^16.8.6 || ^17.0.0",
     "react-dom": "^16.8.6 || ^17.0.0"

--- a/packages/react-jsx-highstock/package.json
+++ b/packages/react-jsx-highstock/package.json
@@ -66,7 +66,7 @@
     "react-jsx-highcharts": "4.3.1"
   },
   "peerDependencies": {
-    "highcharts": "^8.0.0 || ^9.0.0",
+    "highcharts": "^8.0.0 || ^9.0.0 || ^10.0.0",
     "prop-types": "^15.0.0",
     "react": "^16.8.6 || ^17.0.0",
     "react-dom": "^16.8.6 || ^17.0.0"


### PR DESCRIPTION
This allows highcharts v10 in peer dependencies.

Tests pass and it seems to work okay.