### PR TITLE
Fix build and dependency badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ![React JSX Highcharts](https://user-images.githubusercontent.com/2003804/40681848-2d0f5ce2-6382-11e8-8ce9-cd49c409ad2e.png)
 
-[![Build Status](https://travis-ci.com/whawker/react-jsx-highcharts.svg?branch=master)](https://travis-ci.com/whawker/react-jsx-highcharts)
+[![Build Status](https://github.com/whawker/react-jsx-highcharts/actions/workflows/test.yml/badge.svg?branch=master)](https://github.com/whawker/react-jsx-highcharts/actions/workflows/test.yml)
 
 [Highcharts](https://github.com/highcharts/highcharts) built with **proper React components**. More that just a simple wrapper - utilises the power of React props to create dynamic charts!
 

--- a/packages/react-jsx-highcharts/README.md
+++ b/packages/react-jsx-highcharts/README.md
@@ -1,6 +1,6 @@
 ![React JSX Highcharts](https://user-images.githubusercontent.com/2003804/40681848-2d0f5ce2-6382-11e8-8ce9-cd49c409ad2e.png)
 
-[![Build Status](https://github.com/whawker/react-jsx-highcharts/actions/workflows/test.yml/badge.svg?branch=master)](https://github.com/whawker/react-jsx-highcharts/actions/workflows/test.yml) ![npm version](https://img.shields.io/npm/v/react-jsx-highcharts.svg) [![dependencies Status](https://david-dm.org/whawker/react-jsx-highcharts/status.svg?path=packages/react-jsx-highcharts)](https://david-dm.org/whawker/react-jsx-highcharts?path=packages/react-jsx-highcharts)
+[![Build Status](https://github.com/whawker/react-jsx-highcharts/actions/workflows/test.yml/badge.svg?branch=master)](https://github.com/whawker/react-jsx-highcharts/actions/workflows/test.yml) ![npm version](https://img.shields.io/npm/v/react-jsx-highcharts.svg) ![dependencies Status](https://img.shields.io/librariesio/release/npm/react-jsx-highcharts)
 
 ## Introduction
 

--- a/packages/react-jsx-highcharts/README.md
+++ b/packages/react-jsx-highcharts/README.md
@@ -1,6 +1,6 @@
 ![React JSX Highcharts](https://user-images.githubusercontent.com/2003804/40681848-2d0f5ce2-6382-11e8-8ce9-cd49c409ad2e.png)
 
-[![Build Status](https://travis-ci.com/whawker/react-jsx-highcharts.svg?branch=master)](https://travis-ci.com/whawker/react-jsx-highcharts) ![npm version](https://img.shields.io/npm/v/react-jsx-highcharts.svg) [![dependencies Status](https://david-dm.org/whawker/react-jsx-highcharts/status.svg?path=packages/react-jsx-highcharts)](https://david-dm.org/whawker/react-jsx-highcharts?path=packages/react-jsx-highcharts)
+[![Build Status](https://github.com/whawker/react-jsx-highcharts/actions/workflows/test.yml/badge.svg?branch=master)](https://github.com/whawker/react-jsx-highcharts/actions/workflows/test.yml) ![npm version](https://img.shields.io/npm/v/react-jsx-highcharts.svg) [![dependencies Status](https://david-dm.org/whawker/react-jsx-highcharts/status.svg?path=packages/react-jsx-highcharts)](https://david-dm.org/whawker/react-jsx-highcharts?path=packages/react-jsx-highcharts)
 
 ## Introduction
 

--- a/packages/react-jsx-highmaps/README.md
+++ b/packages/react-jsx-highmaps/README.md
@@ -1,6 +1,6 @@
 ![React JSX Highmaps](https://user-images.githubusercontent.com/2003804/47213017-ac588080-d391-11e8-8711-9e7c4e2fadec.png)
 
-[![Build Status](https://github.com/whawker/react-jsx-highcharts/actions/workflows/test.yml/badge.svg?branch=master)](https://github.com/whawker/react-jsx-highcharts/actions/workflows/test.yml) ![npm version](https://img.shields.io/npm/v/react-jsx-highmaps.svg) [![dependencies Status](https://david-dm.org/whawker/react-jsx-highcharts/status.svg?path=packages/react-jsx-highmaps)](https://david-dm.org/whawker/react-jsx-highcharts?path=packages/react-jsx-highmaps)
+[![Build Status](https://github.com/whawker/react-jsx-highcharts/actions/workflows/test.yml/badge.svg?branch=master)](https://github.com/whawker/react-jsx-highcharts/actions/workflows/test.yml) ![npm version](https://img.shields.io/npm/v/react-jsx-highmaps.svg) ![dependencies Status](https://img.shields.io/librariesio/release/npm/react-jsx-highmaps)
 
 ## Introduction
 

--- a/packages/react-jsx-highmaps/README.md
+++ b/packages/react-jsx-highmaps/README.md
@@ -1,6 +1,6 @@
 ![React JSX Highmaps](https://user-images.githubusercontent.com/2003804/47213017-ac588080-d391-11e8-8711-9e7c4e2fadec.png)
 
-[![Build Status](https://travis-ci.com/whawker/react-jsx-highcharts.svg?branch=master)](https://travis-ci.com/whawker/react-jsx-highcharts) ![npm version](https://img.shields.io/npm/v/react-jsx-highmaps.svg) [![dependencies Status](https://david-dm.org/whawker/react-jsx-highcharts/status.svg?path=packages/react-jsx-highmaps)](https://david-dm.org/whawker/react-jsx-highcharts?path=packages/react-jsx-highmaps)
+[![Build Status](https://github.com/whawker/react-jsx-highcharts/actions/workflows/test.yml/badge.svg?branch=master)](https://github.com/whawker/react-jsx-highcharts/actions/workflows/test.yml) ![npm version](https://img.shields.io/npm/v/react-jsx-highmaps.svg) [![dependencies Status](https://david-dm.org/whawker/react-jsx-highcharts/status.svg?path=packages/react-jsx-highmaps)](https://david-dm.org/whawker/react-jsx-highcharts?path=packages/react-jsx-highmaps)
 
 ## Introduction
 

--- a/packages/react-jsx-highstock/README.md
+++ b/packages/react-jsx-highstock/README.md
@@ -1,6 +1,6 @@
 ![React JSX Highstock](https://user-images.githubusercontent.com/2003804/40682476-c1ea6be4-6383-11e8-826c-a617db5ef726.png)
 
-[![Build Status](https://github.com/whawker/react-jsx-highcharts/actions/workflows/test.yml/badge.svg?branch=master)](https://github.com/whawker/react-jsx-highcharts/actions/workflows/test.yml) ![npm version](https://img.shields.io/npm/v/react-jsx-highstock.svg) [![dependencies Status](https://david-dm.org/whawker/react-jsx-highcharts/status.svg?path=packages/react-jsx-highstock)](https://david-dm.org/whawker/react-jsx-highcharts?path=packages/react-jsx-highstock)
+[![Build Status](https://github.com/whawker/react-jsx-highcharts/actions/workflows/test.yml/badge.svg?branch=master)](https://github.com/whawker/react-jsx-highcharts/actions/workflows/test.yml) ![npm version](https://img.shields.io/npm/v/react-jsx-highstock.svg) ![dependencies Status](https://img.shields.io/librariesio/release/npm/react-jsx-highstock)
 
 This package exposes everything from `react-jsx-highcharts`, but additionally provides components for building **Highstock** charts. It is encouraged to familiarize yourself with both READMEs.
 

--- a/packages/react-jsx-highstock/README.md
+++ b/packages/react-jsx-highstock/README.md
@@ -1,6 +1,6 @@
 ![React JSX Highstock](https://user-images.githubusercontent.com/2003804/40682476-c1ea6be4-6383-11e8-826c-a617db5ef726.png)
 
-[![Build Status](https://travis-ci.com/whawker/react-jsx-highcharts.svg?branch=master)](https://travis-ci.com/whawker/react-jsx-highcharts) ![npm version](https://img.shields.io/npm/v/react-jsx-highstock.svg) [![dependencies Status](https://david-dm.org/whawker/react-jsx-highcharts/status.svg?path=packages/react-jsx-highstock)](https://david-dm.org/whawker/react-jsx-highcharts?path=packages/react-jsx-highstock)
+[![Build Status](https://github.com/whawker/react-jsx-highcharts/actions/workflows/test.yml/badge.svg?branch=master)](https://github.com/whawker/react-jsx-highcharts/actions/workflows/test.yml) ![npm version](https://img.shields.io/npm/v/react-jsx-highstock.svg) [![dependencies Status](https://david-dm.org/whawker/react-jsx-highcharts/status.svg?path=packages/react-jsx-highstock)](https://david-dm.org/whawker/react-jsx-highcharts?path=packages/react-jsx-highstock)
 
 This package exposes everything from `react-jsx-highcharts`, but additionally provides components for building **Highstock** charts. It is encouraged to familiarize yourself with both READMEs.
 


### PR DESCRIPTION
This fixes the badges in README.

The build status was still referencing travis.
The david-dm.org has apparently been down for some time already.