### PR TITLE
Replace U+00A0 character with normal space

### DIFF
--- a/packages/react-jsx-highcharts/package.json
+++ b/packages/react-jsx-highcharts/package.json
@@ -65,7 +65,7 @@
     "uuid": "^9.0.0"
   },
   "peerDependencies": {
-    "highcharts": "^9.1.2 || ^10.0.0",
+    "highcharts": "^9.1.2 || ^10.0.0",
     "react": "^17.0.0 || ^18.0.0",
     "react-dom": "^17.0.0 || ^18.0.0"
   },

--- a/packages/react-jsx-highmaps/package.json
+++ b/packages/react-jsx-highmaps/package.json
@@ -48,7 +48,7 @@
     "react-jsx-highcharts": "5.0.0"
   },
   "peerDependencies": {
-    "highcharts": "^9.1.2 || ^10.0.0",
+    "highcharts": "^9.1.2 || ^10.0.0",
     "react": "^17.0.0 || ^18.0.0",
     "react-dom": "^17.0.0 || ^18.0.0"
   },

--- a/packages/react-jsx-highstock/package.json
+++ b/packages/react-jsx-highstock/package.json
@@ -65,7 +65,7 @@
     "react-jsx-highcharts": "5.0.0"
   },
   "peerDependencies": {
-    "highcharts": "^9.1.2 || ^10.0.0",
+    "highcharts": "^9.1.2 || ^10.0.0",
     "react": "^17.0.0 || ^18.0.0",
     "react-dom": "^17.0.0 || ^18.0.0"
   },


### PR DESCRIPTION
These probably snuck in by mistake at some point 'cause I see no point of using non-breaking space in package.json.