### PR TITLE
fix: options3d axisLabelPosition default value

### DIFF
--- a/packages/react-jsx-highcharts/src/components/Options3d/Options3d.tsx
+++ b/packages/react-jsx-highcharts/src/components/Options3d/Options3d.tsx
@@ -27,8 +27,7 @@ const Options3d = memo(
     depth = 100,
     fitToPlot = true,
     viewDistance = 25,
-    // @ts-expect-error 'default' is not assignable to type AxisLabelPosition
-    axisLabelPosition = 'default',
+    axisLabelPosition = null,
     frame = DEFAULT_FRAME,
     ...restProps
   }: Options3dProps) => {

--- a/packages/react-jsx-highcharts/test/components/Options3d/Options3d.spec.jsx
+++ b/packages/react-jsx-highcharts/test/components/Options3d/Options3d.spec.jsx
@@ -13,7 +13,7 @@ const defaultProps = {
   depth: 100,
   fitToPlot: true,
   viewDistance: 25,
-  axisLabelPosition: 'default',
+  axisLabelPosition: null,
   frame: {
     visible: 'default',
     size: 1,


### PR DESCRIPTION
Fixes default value.
It is null according to documentation: https://api.highcharts.com/highcharts/chart.options3d.axisLabelPosition