### PR TITLE
Remove warnings for highcharts < 12

### DIFF
--- a/packages/react-jsx-highcharts/src/utils/warnings.ts
+++ b/packages/react-jsx-highcharts/src/utils/warnings.ts
@@ -38,36 +38,6 @@ const moduleToImportPath = {
   xrange: 'modules/xrange'
 };
 
-const moduleToVarName = {
-  annotations: 'addAnnotations',
-  more: 'addHighchartsMore',
-  threeD: 'addHighcharts3DModule',
-  bullet: 'addBulletModule',
-  cylinder: 'addCylinderModule',
-  dependencyWheel: 'addDependencyWheelModule',
-  funnel: 'addFunnelModule',
-  funnel3d: 'addFunnel3dModule',
-  histogram: 'addHistogramBellCurveModule',
-  item: 'addItemModule',
-  networkgraph: 'addNetworkGraphModule',
-  organization: 'addOrganizationModule',
-  pareto: 'addParetoModule',
-  pyramid3d: 'addPyramid3dModule',
-  sankey: 'addSankeyModule',
-  solidgauge: 'addSolidGaugeModule',
-  streamgraph: 'addStreamGraphModule',
-  sunburst: 'addSunburstModule',
-  tilemap: 'addTilemapModule',
-  timeline: 'addTimelineModule',
-  treemap: 'addTreemapModule',
-  variablepie: 'addVariablePieModule',
-  variwide: 'addVariwideModule',
-  vector: 'addVectorModule',
-  venn: 'addVennModule',
-  windbarb: 'addWindBarbModule',
-  xrange: 'addXRangeModule'
-};
-
 const moduleToFeatureMap = {
   annotations: ['annotations'],
   more: [
@@ -123,13 +93,9 @@ const findModules = feature => {
   return modules;
 };
 
-const generateLines = (modules: Array<keyof typeof moduleToVarName>) => {
+const generateLines = (modules: Array<keyof typeof moduleToImportPath>) => {
   const importLines = modules.map(
-    module =>
-      `%c %cimport %c${moduleToVarName[module]} %cfrom %c'highcharts/${moduleToImportPath[module]}'%c;`
-  );
-  const applyLines = modules.map(
-    module => `%c %c${moduleToVarName[module]}%c(Highcharts);`
+    module => `%c %cimport %c'highcharts/${moduleToImportPath[module]}'%c;`
   );
   const importStyling = modules.map(() => [
     descNewLine,
@@ -145,15 +111,14 @@ const generateLines = (modules: Array<keyof typeof moduleToVarName>) => {
     descDefaultCSS
   ]);
 
-  return { importLines, applyLines, importStyling, applyStyling };
+  return { importLines, importStyling, applyStyling };
 };
 
 const logDetailedErrorMessage = (
   warning: string,
-  modules: Array<keyof typeof moduleToVarName>
+  modules: Array<keyof typeof moduleToImportPath>
 ) => {
-  const { importLines, applyLines, importStyling, applyStyling } =
-    generateLines(modules);
+  const { importLines, importStyling, applyStyling } = generateLines(modules);
   const isMultiModule = modules.length > 1;
 
   console.group('React JSX Highcharts error');
@@ -171,13 +136,7 @@ const logDetailedErrorMessage = (
       }, try adding
     %c
     %c %cimport %cHighcharts %cfrom %c'highcharts'%c;
-    ${importLines.join('\n')}
-    %c
-    %c %c// For highcharts below version 12:
-    %c %c// After imports, but before component - apply additional functionality from module${
-      isMultiModule ? 's' : ''
-    } to Highcharts
-    ${applyLines.join('\n')}`.replace(/^ +/gm, ''),
+    ${importLines.join('\n')}`.replace(/^ +/gm, ''),
       descNewLine,
       descNewLine,
       descKeywordCSS,

--- a/packages/react-jsx-highcharts/test/utils/warnings.spec.js
+++ b/packages/react-jsx-highcharts/test/utils/warnings.spec.js
@@ -53,11 +53,7 @@ describe('utils/warnings', () => {
           'You likely need to import the additional module, try adding\n' +
             '%c\n' +
             "%c %cimport %cHighcharts %cfrom %c'highcharts'%c;\n" +
-            "%c %cimport %caddSankeyModule %cfrom %c'highcharts/modules/sankey'%c;\n" +
-            '%c\n' +
-            '%c %c// For highcharts below version 12:\n' +
-            '%c %c// After imports, but before component - apply additional functionality from module to Highcharts\n' +
-            '%c %caddSankeyModule%c(Highcharts);'
+            "%c %cimport %c'highcharts/modules/sankey'%c;"
         ])
       );
     });
@@ -78,17 +74,10 @@ describe('utils/warnings', () => {
           'You likely need to import the additional modules, try adding\n' +
             '%c\n' +
             "%c %cimport %cHighcharts %cfrom %c'highcharts'%c;\n" +
-            "%c %cimport %caddHighcharts3DModule %cfrom %c'highcharts/highcharts-3d'%c;\n" +
-            "%c %cimport %caddCylinderModule %cfrom %c'highcharts/modules/cylinder'%c;\n" +
-            "%c %cimport %caddFunnel3dModule %cfrom %c'highcharts/modules/funnel3d'%c;\n" +
-            "%c %cimport %caddPyramid3dModule %cfrom %c'highcharts/modules/pyramid3d'%c;\n" +
-            '%c\n' +
-            '%c %c// For highcharts below version 12:\n' +
-            '%c %c// After imports, but before component - apply additional functionality from modules to Highcharts\n' +
-            '%c %caddHighcharts3DModule%c(Highcharts);\n' +
-            '%c %caddCylinderModule%c(Highcharts);\n' +
-            '%c %caddFunnel3dModule%c(Highcharts);\n' +
-            '%c %caddPyramid3dModule%c(Highcharts);'
+            "%c %cimport %c'highcharts/highcharts-3d'%c;\n" +
+            "%c %cimport %c'highcharts/modules/cylinder'%c;\n" +
+            "%c %cimport %c'highcharts/modules/funnel3d'%c;\n" +
+            "%c %cimport %c'highcharts/modules/pyramid3d'%c;"
         ])
       );
     });


### PR DESCRIPTION
As highcharts < 12 is not supported anymore, remove instructions for it in the warnings.