### PR TITLE
Fix eventhandler types

### DIFF
--- a/packages/react-jsx-highcharts/src/components/Axis/Axis.tsx
+++ b/packages/react-jsx-highcharts/src/components/Axis/Axis.tsx
@@ -15,18 +15,29 @@ import type {
   XAxisOptions,
   YAxisOptions,
   ZAxisOptions,
-  Axis as HighchartsAxis
+  Axis as HighchartsAxis,
+  XAxisEventsOptions,
+  YAxisEventsOptions,
+  ZAxisEventsOptions
 } from 'highcharts';
 import type { AxisContextValue } from '../AxisContext/index.ts';
+import type { EventsToHandlerProps } from '../../utils/events.ts';
 
 type BaseAxisProps = {
   children?: ReactNode;
   dynamicAxis?: boolean;
   isX?: boolean;
 };
-export type XAxisProps = BaseAxisProps & XAxisOptions;
-export type YAxisProps = BaseAxisProps & YAxisOptions;
-export type ZAxisProps = BaseAxisProps & ZAxisOptions;
+
+export type XAxisProps = BaseAxisProps &
+  XAxisOptions &
+  EventsToHandlerProps<XAxisEventsOptions>;
+export type YAxisProps = BaseAxisProps &
+  YAxisOptions &
+  EventsToHandlerProps<YAxisEventsOptions>;
+export type ZAxisProps = BaseAxisProps &
+  ZAxisOptions &
+  EventsToHandlerProps<ZAxisEventsOptions>;
 
 type AxisProps = XAxisProps | YAxisProps | ZAxisProps;
 

--- a/packages/react-jsx-highcharts/src/components/Chart/Chart.tsx
+++ b/packages/react-jsx-highcharts/src/components/Chart/Chart.tsx
@@ -4,38 +4,14 @@ import useModifiedProps from '../UseModifiedProps/index.ts';
 import useChart from '../UseChart/index.ts';
 import useManualEventHandlers from '../UseManualEventHandlers/index.ts';
 
-import type {
-  ChartAddSeriesCallbackFunction,
-  ExportingAfterPrintCallbackFunction,
-  ExportingBeforePrintCallbackFunction,
-  ChartClickCallbackFunction,
-  DrilldownCallbackFunction,
-  DrillupCallbackFunction,
-  DrillupAllCallbackFunction,
-  ExportDataCallbackFunction,
-  ChartLoadCallbackFunction,
-  ChartRedrawCallbackFunction,
-  ChartRenderCallbackFunction,
-  ChartSelectionCallbackFunction,
-  ChartOptions
-} from 'highcharts';
+import type { ChartOptions, ChartEventsOptions } from 'highcharts';
 import type { ChartContextValue } from '../UseChart/index.ts';
+import type { EventsToHandlerProps } from '../../utils/events.ts';
 
 export type ChartProps = {
-  onAddSeries?: ChartAddSeriesCallbackFunction;
-  onAfterPrint?: ExportingAfterPrintCallbackFunction;
-  onBeforePrint?: ExportingBeforePrintCallbackFunction;
-  onClick?: ChartClickCallbackFunction;
-  onDrilldown?: DrilldownCallbackFunction;
-  onDrillup?: DrillupCallbackFunction;
-  onDrillupall?: DrillupAllCallbackFunction;
-  onExportData?: ExportDataCallbackFunction;
-  onLoad?: ChartLoadCallbackFunction;
-  onRedraw?: ChartRedrawCallbackFunction;
-  onRender?: ChartRenderCallbackFunction;
-  onSelection?: ChartSelectionCallbackFunction;
-  [x: string]: unknown; // TODO: this is here to allow eventhandlers like onAfterAddSeries
-} & Partial<ChartOptions>;
+  [x: string]: unknown; // TODO: this is here to allow untyped eventhandlers like onAfterAddSeries
+} & EventsToHandlerProps<ChartEventsOptions> &
+  Partial<ChartOptions>;
 
 const Chart = memo(
   ({ type = 'line', width, height, ...restProps }: ChartProps) => {

--- a/packages/react-jsx-highcharts/src/components/Chart/Chart.tsx
+++ b/packages/react-jsx-highcharts/src/components/Chart/Chart.tsx
@@ -8,9 +8,7 @@ import type { ChartOptions, ChartEventsOptions } from 'highcharts';
 import type { ChartContextValue } from '../UseChart/index.ts';
 import type { EventsToHandlerProps } from '../../utils/events.ts';
 
-export type ChartProps = {
-  [x: string]: unknown; // TODO: this is here to allow untyped eventhandlers like onAfterAddSeries
-} & EventsToHandlerProps<ChartEventsOptions> &
+export type ChartProps = {} & EventsToHandlerProps<ChartEventsOptions> &
   Partial<ChartOptions>;
 
 const Chart = memo(

--- a/packages/react-jsx-highcharts/src/components/ColorAxis/ColorAxis.tsx
+++ b/packages/react-jsx-highcharts/src/components/ColorAxis/ColorAxis.tsx
@@ -2,7 +2,8 @@ import { useEffect, useRef, useState } from 'react';
 import { v4 as uuid } from 'uuid';
 import {
   getNonEventHandlerProps,
-  getEventsConfig
+  getEventsConfig,
+  type EventsToHandlerProps
 } from '../../utils/events.ts';
 import ColorAxisContext from '../ColorAxisContext/index.ts';
 import useModifiedProps from '../UseModifiedProps/index.ts';
@@ -12,19 +13,16 @@ import createProvidedColorAxis from './createProvidedColorAxis.ts';
 import type { ReactNode } from 'react';
 import type {
   Axis,
-  AxisSetExtremesEventCallbackFunction,
-  LegendItemClickCallbackFunction,
-  ColorAxisOptions
+  ColorAxisOptions,
+  ColorAxisEventsOptions
 } from 'highcharts';
 import type { ChartContextValue } from '../UseChart/index.ts';
 import type { ColorAxisContextValue } from '../ColorAxisContext/index.ts';
 
 type ColorAxisProps = {
   children?: ReactNode;
-  onAfterSetExtremes?: AxisSetExtremesEventCallbackFunction;
-  onLegendItemClick?: LegendItemClickCallbackFunction;
-  onSetExtremes?: AxisSetExtremesEventCallbackFunction;
-} & Partial<ColorAxisOptions>;
+} & EventsToHandlerProps<ColorAxisEventsOptions> &
+  Partial<ColorAxisOptions>;
 
 const ColorAxis = ({ children = null, ...restProps }: ColorAxisProps) => {
   const chart = useChart();
@@ -72,8 +70,7 @@ const ColorAxis = ({ children = null, ...restProps }: ColorAxisProps) => {
   );
 };
 
-// @ts-expect-error TODO
-const getColorAxisConfig = props => {
+const getColorAxisConfig = (props: Omit<ColorAxisProps, 'children'>) => {
   const { id = uuid, ...rest } = props;
 
   const colorAxisId = typeof id === 'function' ? id() : id;
@@ -87,8 +84,10 @@ const getColorAxisConfig = props => {
   };
 };
 
-// @ts-expect-error TODO
-const createColorAxis = (chart: ChartContextValue, props) => {
+const createColorAxis = (
+  chart: ChartContextValue,
+  props: Omit<ColorAxisProps, 'children'>
+) => {
   const opts = getColorAxisConfig(props);
   return chart.addColorAxis(opts, false);
 };

--- a/packages/react-jsx-highcharts/src/components/Highcharts3dChart/Highcharts3dChart.tsx
+++ b/packages/react-jsx-highcharts/src/components/Highcharts3dChart/Highcharts3dChart.tsx
@@ -2,7 +2,7 @@ import HighchartsChart from '../HighchartsChart/index.ts';
 import Options3d from '../Options3d/index.ts';
 
 import type { Chart3dOptions } from 'highcharts';
-import type { ReactNode } from 'react';
+import type { ComponentProps, ReactNode } from 'react';
 
 const CHART = {
   options3d: { enabled: true }
@@ -14,7 +14,8 @@ const ZAXIS = {
 type Highcharts3dChartProps = { children?: ReactNode } & Omit<
   Chart3dOptions,
   'enabled'
->;
+> &
+  ComponentProps<typeof HighchartsChart>;
 
 const Highcharts3dChart = ({
   children,

--- a/packages/react-jsx-highcharts/src/components/HighchartsChart/HighchartsChart.tsx
+++ b/packages/react-jsx-highcharts/src/components/HighchartsChart/HighchartsChart.tsx
@@ -11,7 +11,6 @@ export type HighchartsChartProps = {
   className?: string;
   containerProps?: Record<string, unknown>;
   children?: ReactNode;
-  [x: string]: unknown; // TODO: this is here to allow eventhandlers like onLegendItemClick
 } & Partial<Options>;
 
 const HighchartsChart = (props: HighchartsChartProps) => {

--- a/packages/react-jsx-highcharts/src/components/Series/Series.tsx
+++ b/packages/react-jsx-highcharts/src/components/Series/Series.tsx
@@ -22,15 +22,23 @@ import type { SeriesContextValue } from '../SeriesContext/index.ts';
 // @ts-expect-error TODO
 const EMPTY_ARRAY = [];
 
-export type SeriesProps<TSeriesOptions = Partial<HC.SeriesOptions>> = {
+export type SeriesProps<TSeriesOptions = HC.SeriesOptions> = {
   children?: ReactNode;
   jsxOptions?: {
     updatePoints?: boolean;
   };
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  [x: string]: any; // TODO: this is here to allow eventhandlers untyped in highcharts
+  isDataEqual: (a: any, b: any) => boolean;
 } & EventsToHandlerProps<HC.SeriesEventsOptionsObject> &
   Partial<Omit<TSeriesOptions, 'type'>>;
+
+type PrivateSeriesProps = {
+  id?: string | (() => string);
+  type?: string;
+  visible?: boolean;
+  axisId?: string;
+  requiresAxis?: boolean;
+};
 
 /**
  *
@@ -49,7 +57,7 @@ const Series = memo(
     requiresAxis = true,
     jsxOptions,
     ...restProps
-  }: SeriesProps<P>) => {
+  }: SeriesProps<P> & PrivateSeriesProps) => {
     const seriesProps = { id, data, type, visible, ...restProps };
 
     /*

--- a/packages/react-jsx-highcharts/src/components/Series/Series.tsx
+++ b/packages/react-jsx-highcharts/src/components/Series/Series.tsx
@@ -3,7 +3,8 @@ import { v4 as uuid } from 'uuid';
 import SeriesContext from '../SeriesContext/index.ts';
 import {
   getNonEventHandlerProps,
-  getEventsConfig
+  getEventsConfig,
+  type EventsToHandlerProps
 } from '../../utils/events.ts';
 import getModifiedProps from '../../utils/getModifiedProps.ts';
 import { logSeriesErrorMessage } from '../../utils/warnings.ts';
@@ -26,19 +27,10 @@ export type SeriesProps<TSeriesOptions = Partial<HC.SeriesOptions>> = {
   jsxOptions?: {
     updatePoints?: boolean;
   };
-  onAfterAnimate?: HC.SeriesAfterAnimateCallbackFunction;
-  onCheckboxClick?: HC.SeriesEventsOptionsObject['checkboxClick'];
-  onClick?: HC.SeriesClickCallbackFunction;
-  onHide?: HC.SeriesHideCallbackFunction;
-  onLegendItemClick?: HC.SeriesLegendItemClickCallbackFunction;
-
-  onMouseOut?: HC.SeriesMouseOutCallbackFunction;
-  onMouseOver?: HC.SeriesMouseOverCallbackFunction;
-  onSetRootNode?: HC.SeriesEventsOptionsObject['setRootNode'];
-  onShow?: HC.SeriesShowCallbackFunction;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  [x: string]: any; // TODO: this is here to allow unknown eventhandlers
-} & Partial<Omit<TSeriesOptions, 'type'>>;
+  [x: string]: any; // TODO: this is here to allow eventhandlers untyped in highcharts
+} & EventsToHandlerProps<HC.SeriesEventsOptionsObject> &
+  Partial<Omit<TSeriesOptions, 'type'>>;
 
 /**
  *

--- a/packages/react-jsx-highcharts/src/utils/events.ts
+++ b/packages/react-jsx-highcharts/src/utils/events.ts
@@ -42,3 +42,33 @@ export const getEventsConfig = <P extends Record<string, unknown>>(
 
 const _isEventKey = (key: string, value: unknown) =>
   key.indexOf('on') === 0 && key.length > 2 && typeof value === 'function';
+
+/*
+ Converts all keys of a type to event handler props prefixed with "on" and capitalized.
+ example:
+ type ChartEventsOptions = {
+    addSeries?: ChartAddSeriesCallbackFunction | undefined;
+    afterPrint?: ExportingAfterPrintCallbackFunction | undefined;
+    beforePrint?: ExportingBeforePrintCallbackFunction | undefined;
+    click?: ChartClickCallbackFunction | undefined;
+ };
+
+ type PrefixedChartEvents = EventsToHandlerProps<ChartEventsOptions>;
+ // Resulting type:
+ {
+    onAddSeries?: ChartAddSeriesCallbackFunction | undefined;
+    onAfterPrint?: ExportingAfterPrintCallbackFunction | undefined;
+    onBeforePrint?: ExportingBeforePrintCallbackFunction | undefined;
+    onClick?: ChartClickCallbackFunction | undefined;
+ }
+ */
+export type EventsToHandlerProps<T> = PickFunctionProps<PropsToHandlers<T>>;
+
+type PropsToHandlers<T> = {
+  [K in keyof T as `on${Capitalize<string & K>}`]: T[K];
+};
+
+type PickFunctionProps<T> = {
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-function-type
+  [P in keyof T as T[P] extends Function | undefined ? P : never]: T[P];
+};


### PR DESCRIPTION
- Add typescript utility ```EventsToHandlerProps``` that converts Highcharts event types to react eventhandlers
- Add back accidentally deleted Axis eventhandler types
- Remove unnecessary HighchartsChart ```[x: string]: unknown;``` as there are no eventhandlers on HighchartsChart
- Change ColorAxis to use ```EventsToHandlerProps```
- Change Series to use ```EventsToHandlerProps```
- Change Chart to use ```EventsToHandlerProps```

These problems were found in 6.0.0-alpha.0.

@whawker I think that after these fixes the v6 is good to go, what do you think?